### PR TITLE
Fix forward auth - use formatHeaders for API auth across app

### DIFF
--- a/apps/web/src/components/common/api.tsx
+++ b/apps/web/src/components/common/api.tsx
@@ -1,0 +1,20 @@
+// -- API Helper functions --------------------------------------------------------
+
+function getToken(): string {
+  return localStorage.getItem("stirling-token") || "";
+}
+
+export function formatHeaders(init?: HeadersInit): Headers {
+  const headers = new Headers(init);
+
+  // We only want to add the authorization header if there is a token.
+  // This is to avoid sending the authorization header with an empty token,
+  // which could cause issues with forward auth requestd through a proxy
+  // which may try to authenticate the request with an empty token.
+  const token = getToken();
+  if (token && token.length > 0) {
+    headers.set("Authorization", `Bearer ${token}`);
+  }
+
+  return headers;
+}

--- a/apps/web/src/components/tools/barcode-read-settings.tsx
+++ b/apps/web/src/components/tools/barcode-read-settings.tsx
@@ -1,10 +1,7 @@
 import { Check, Copy, Loader2 } from "lucide-react";
 import { useState } from "react";
 import { useFileStore } from "@/stores/file-store";
-
-function getToken(): string {
-  return localStorage.getItem("stirling-token") || "";
-}
+import { formatHeaders } from "@/components/common/api";
 
 export function BarcodeReadSettings() {
   const { files, processing, error, setProcessing, setError } = useFileStore();
@@ -24,7 +21,7 @@ export function BarcodeReadSettings() {
 
       const res = await fetch("/api/v1/tools/barcode-read", {
         method: "POST",
-        headers: { Authorization: `Bearer ${getToken()}` },
+        headers: formatHeaders({}),
         body: formData,
       });
 

--- a/apps/web/src/components/tools/bulk-rename-settings.tsx
+++ b/apps/web/src/components/tools/bulk-rename-settings.tsx
@@ -1,10 +1,7 @@
 import { Download, Loader2 } from "lucide-react";
 import { useState } from "react";
 import { useFileStore } from "@/stores/file-store";
-
-function getToken(): string {
-  return localStorage.getItem("stirling-token") || "";
-}
+import { formatHeaders } from "@/components/common/api";
 
 export function BulkRenameSettings() {
   const { files, processing, error, setProcessing, setError } = useFileStore();
@@ -28,7 +25,7 @@ export function BulkRenameSettings() {
 
       const res = await fetch("/api/v1/tools/bulk-rename", {
         method: "POST",
-        headers: { Authorization: `Bearer ${getToken()}` },
+        headers: formatHeaders({}),
         body: formData,
       });
 

--- a/apps/web/src/components/tools/collage-settings.tsx
+++ b/apps/web/src/components/tools/collage-settings.tsx
@@ -1,10 +1,7 @@
 import { Download, Loader2 } from "lucide-react";
 import { useState } from "react";
+import { formatHeaders } from "@/components/common/api";
 import { useFileStore } from "@/stores/file-store";
-
-function getToken(): string {
-  return localStorage.getItem("stirling-token") || "";
-}
 
 type Layout = "2x2" | "3x3" | "1x3" | "2x1" | "3x1" | "1x2";
 
@@ -43,7 +40,7 @@ export function CollageSettings() {
 
       const res = await fetch("/api/v1/tools/collage", {
         method: "POST",
-        headers: { Authorization: `Bearer ${getToken()}` },
+        headers: formatHeaders({}),
         body: formData,
       });
 

--- a/apps/web/src/components/tools/color-palette-settings.tsx
+++ b/apps/web/src/components/tools/color-palette-settings.tsx
@@ -1,10 +1,7 @@
 import { Check, Copy, Loader2 } from "lucide-react";
 import { useState } from "react";
+import { formatHeaders } from "@/components/common/api";
 import { useFileStore } from "@/stores/file-store";
-
-function getToken(): string {
-  return localStorage.getItem("stirling-token") || "";
-}
 
 export function ColorPaletteSettings() {
   const { files, processing, error, setProcessing, setError } = useFileStore();
@@ -24,7 +21,7 @@ export function ColorPaletteSettings() {
 
       const res = await fetch("/api/v1/tools/color-palette", {
         method: "POST",
-        headers: { Authorization: `Bearer ${getToken()}` },
+        headers: formatHeaders({}),
         body: formData,
       });
 

--- a/apps/web/src/components/tools/compare-settings.tsx
+++ b/apps/web/src/components/tools/compare-settings.tsx
@@ -1,10 +1,7 @@
 import { Download, Loader2, Upload } from "lucide-react";
 import { useRef, useState } from "react";
+import { formatHeaders } from "@/components/common/api";
 import { useFileStore } from "@/stores/file-store";
-
-function getToken(): string {
-  return localStorage.getItem("stirling-token") || "";
-}
 
 export function CompareSettings() {
   const { files, processing, error, setProcessing, setError, setProcessedUrl } = useFileStore();
@@ -28,7 +25,7 @@ export function CompareSettings() {
 
       const res = await fetch("/api/v1/tools/compare", {
         method: "POST",
-        headers: { Authorization: `Bearer ${getToken()}` },
+        headers: formatHeaders({}),
         body: formData,
       });
 

--- a/apps/web/src/components/tools/compose-settings.tsx
+++ b/apps/web/src/components/tools/compose-settings.tsx
@@ -1,10 +1,7 @@
 import { Download, Loader2, Upload } from "lucide-react";
 import { useRef, useState } from "react";
+import { formatHeaders } from "@/components/common/api";
 import { useFileStore } from "@/stores/file-store";
-
-function getToken(): string {
-  return localStorage.getItem("stirling-token") || "";
-}
 
 export function ComposeSettings() {
   const { files, processing, error, setProcessing, setError, setProcessedUrl, setSizes, setJobId } =
@@ -34,7 +31,7 @@ export function ComposeSettings() {
 
       const res = await fetch("/api/v1/tools/compose", {
         method: "POST",
-        headers: { Authorization: `Bearer ${getToken()}` },
+        headers: formatHeaders({}),
         body: formData,
       });
 

--- a/apps/web/src/components/tools/erase-object-settings.tsx
+++ b/apps/web/src/components/tools/erase-object-settings.tsx
@@ -1,12 +1,9 @@
 import { Download, Redo, Trash2 } from "lucide-react";
 import { useRef, useState } from "react";
+import { formatHeaders } from "@/components/common/api";
 import { ProgressCard } from "@/components/common/progress-card";
 import { useFileStore } from "@/stores/file-store";
 import type { EraserCanvasRef } from "./eraser-canvas";
-
-function getToken(): string {
-  return localStorage.getItem("stirling-token") || "";
-}
 
 interface EraseObjectSettingsProps {
   eraserRef: React.RefObject<EraserCanvasRef | null>;
@@ -113,7 +110,9 @@ export function EraseObjectSettings({
       setProgressPhase("idle");
     };
     xhr.open("POST", "/api/v1/tools/erase-object");
-    xhr.setRequestHeader("Authorization", `Bearer ${getToken()}`);
+    formatHeaders({}).forEach((value, key) => {
+      xhr.setRequestHeader(key, value);
+    });
     xhr.send(formData);
   };
 

--- a/apps/web/src/components/tools/favicon-settings.tsx
+++ b/apps/web/src/components/tools/favicon-settings.tsx
@@ -1,10 +1,7 @@
 import { Download, Loader2 } from "lucide-react";
 import { useState } from "react";
+import { formatHeaders } from "@/components/common/api";
 import { useFileStore } from "@/stores/file-store";
-
-function getToken(): string {
-  return localStorage.getItem("stirling-token") || "";
-}
 
 const SIZES = [
   { name: "favicon-16x16.png", size: "16x16" },
@@ -33,7 +30,7 @@ export function FaviconSettings() {
 
       const res = await fetch("/api/v1/tools/favicon", {
         method: "POST",
-        headers: { Authorization: `Bearer ${getToken()}` },
+        headers: formatHeaders({}),
         body: formData,
       });
 

--- a/apps/web/src/components/tools/find-duplicates-settings.tsx
+++ b/apps/web/src/components/tools/find-duplicates-settings.tsx
@@ -1,10 +1,7 @@
 import { Loader2 } from "lucide-react";
 import { useState } from "react";
+import { formatHeaders } from "@/components/common/api";
 import { useFileStore } from "@/stores/file-store";
-
-function getToken(): string {
-  return localStorage.getItem("stirling-token") || "";
-}
 
 interface DuplicateGroup {
   files: Array<{ filename: string; similarity: number }>;
@@ -35,7 +32,7 @@ export function FindDuplicatesSettings() {
 
       const res = await fetch("/api/v1/tools/find-duplicates", {
         method: "POST",
-        headers: { Authorization: `Bearer ${getToken()}` },
+        headers: formatHeaders({}),
         body: formData,
       });
 

--- a/apps/web/src/components/tools/image-to-pdf-settings.tsx
+++ b/apps/web/src/components/tools/image-to-pdf-settings.tsx
@@ -1,5 +1,6 @@
 import { Download, Loader2 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
+import { formatHeaders } from "@/components/common/api";
 import { useFileStore } from "@/stores/file-store";
 
 const PAGE_SIZES: Record<string, [number, number]> = {
@@ -109,10 +110,6 @@ function PdfPagePreview({
   );
 }
 
-function getToken(): string {
-  return localStorage.getItem("stirling-token") || "";
-}
-
 export function ImageToPdfSettings() {
   const { files, selectedIndex, processing, error, setProcessing, setError } = useFileStore();
   const [pageSize, setPageSize] = useState<"A4" | "Letter" | "A3" | "A5">("A4");
@@ -136,7 +133,7 @@ export function ImageToPdfSettings() {
 
       const res = await fetch("/api/v1/tools/image-to-pdf", {
         method: "POST",
-        headers: { Authorization: `Bearer ${getToken()}` },
+        headers: formatHeaders({}),
         body: formData,
       });
 

--- a/apps/web/src/components/tools/info-settings.tsx
+++ b/apps/web/src/components/tools/info-settings.tsx
@@ -1,10 +1,7 @@
 import { Loader2 } from "lucide-react";
 import { useState } from "react";
+import { formatHeaders } from "@/components/common/api";
 import { useFileStore } from "@/stores/file-store";
-
-function getToken(): string {
-  return localStorage.getItem("stirling-token") || "";
-}
 
 interface ImageInfoData {
   filename: string;
@@ -50,7 +47,7 @@ export function InfoSettings() {
 
       const res = await fetch("/api/v1/tools/info", {
         method: "POST",
-        headers: { Authorization: `Bearer ${getToken()}` },
+        headers: formatHeaders({}),
         body: formData,
       });
 

--- a/apps/web/src/components/tools/ocr-settings.tsx
+++ b/apps/web/src/components/tools/ocr-settings.tsx
@@ -1,11 +1,8 @@
 import { Check, Copy } from "lucide-react";
 import { useRef, useState } from "react";
+import { formatHeaders } from "@/components/common/api";
 import { ProgressCard } from "@/components/common/progress-card";
 import { useFileStore } from "@/stores/file-store";
-
-function getToken(): string {
-  return localStorage.getItem("stirling-token") || "";
-}
 
 type OcrEngine = "tesseract" | "paddleocr";
 
@@ -111,7 +108,9 @@ export function OcrSettings() {
       setProgressPhase("idle");
     };
     xhr.open("POST", "/api/v1/tools/ocr");
-    xhr.setRequestHeader("Authorization", `Bearer ${getToken()}`);
+    formatHeaders({}).forEach((value, key) => {
+      xhr.setRequestHeader(key, value);
+    });
     xhr.send(formData);
   };
 

--- a/apps/web/src/components/tools/qr-generate-settings.tsx
+++ b/apps/web/src/components/tools/qr-generate-settings.tsx
@@ -1,9 +1,6 @@
 import { Download, Loader2 } from "lucide-react";
 import { useState } from "react";
-
-function getToken(): string {
-  return localStorage.getItem("stirling-token") || "";
-}
+import { formatHeaders } from "@/components/common/api";
 
 export function QrGenerateSettings() {
   const [text, setText] = useState("");
@@ -27,10 +24,7 @@ export function QrGenerateSettings() {
     try {
       const res = await fetch("/api/v1/tools/qr-generate", {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${getToken()}`,
-        },
+        headers: formatHeaders({ "Content-Type": "application/json" }),
         body: JSON.stringify({ text, size, errorCorrection, foreground, background }),
       });
 

--- a/apps/web/src/components/tools/split-settings.tsx
+++ b/apps/web/src/components/tools/split-settings.tsx
@@ -1,10 +1,7 @@
 import { Download, Loader2 } from "lucide-react";
 import { useState } from "react";
+import { formatHeaders } from "@/components/common/api";
 import { useFileStore } from "@/stores/file-store";
-
-function getToken(): string {
-  return localStorage.getItem("stirling-token") || "";
-}
 
 export function SplitSettings() {
   const { files, processing, error, setProcessing, setError } = useFileStore();
@@ -26,7 +23,7 @@ export function SplitSettings() {
 
       const res = await fetch("/api/v1/tools/split", {
         method: "POST",
-        headers: { Authorization: `Bearer ${getToken()}` },
+        headers: formatHeaders({}),
         body: formData,
       });
 

--- a/apps/web/src/components/tools/strip-metadata-settings.tsx
+++ b/apps/web/src/components/tools/strip-metadata-settings.tsx
@@ -1,12 +1,9 @@
 import { AlertTriangle, ChevronDown, ChevronRight, Download, Loader2, MapPin } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
+import { formatHeaders } from "@/components/common/api";
 import { ProgressCard } from "@/components/common/progress-card";
 import { useToolProcessor } from "@/hooks/use-tool-processor";
 import { useFileStore } from "@/stores/file-store";
-
-function getToken(): string {
-  return localStorage.getItem("stirling-token") || "";
-}
 
 interface MetadataResult {
   filename: string;
@@ -342,7 +339,7 @@ export function StripMetadataSettings() {
         formData.append("file", currentFile);
         const res = await fetch("/api/v1/tools/strip-metadata/inspect", {
           method: "POST",
-          headers: { Authorization: `Bearer ${getToken()}` },
+          headers: formatHeaders({}),
           body: formData,
           signal: controller.signal,
         });

--- a/apps/web/src/components/tools/svg-to-raster-settings.tsx
+++ b/apps/web/src/components/tools/svg-to-raster-settings.tsx
@@ -1,10 +1,7 @@
 import { Download, Loader2 } from "lucide-react";
 import { useState } from "react";
+import { formatHeaders } from "@/components/common/api";
 import { useFileStore } from "@/stores/file-store";
-
-function getToken(): string {
-  return localStorage.getItem("stirling-token") || "";
-}
 
 export function SvgToRasterSettings() {
   const { files, processing, error, setProcessing, setError, setProcessedUrl, setSizes, setJobId } =
@@ -38,7 +35,7 @@ export function SvgToRasterSettings() {
 
       const res = await fetch("/api/v1/tools/svg-to-raster", {
         method: "POST",
-        headers: { Authorization: `Bearer ${getToken()}` },
+        headers: formatHeaders({}),
         body: formData,
       });
 

--- a/apps/web/src/components/tools/vectorize-settings.tsx
+++ b/apps/web/src/components/tools/vectorize-settings.tsx
@@ -1,10 +1,7 @@
 import { Download, Loader2 } from "lucide-react";
 import { useState } from "react";
+import { formatHeaders } from "@/components/common/api";
 import { useFileStore } from "@/stores/file-store";
-
-function getToken(): string {
-  return localStorage.getItem("stirling-token") || "";
-}
 
 export function VectorizeSettings() {
   const { files, processing, error, setProcessing, setError, setProcessedUrl, setSizes, setJobId } =
@@ -30,7 +27,7 @@ export function VectorizeSettings() {
 
       const res = await fetch("/api/v1/tools/vectorize", {
         method: "POST",
-        headers: { Authorization: `Bearer ${getToken()}` },
+        headers: formatHeaders({}),
         body: formData,
       });
 

--- a/apps/web/src/components/tools/watermark-image-settings.tsx
+++ b/apps/web/src/components/tools/watermark-image-settings.tsx
@@ -1,12 +1,9 @@
 import { Download, Loader2, Upload } from "lucide-react";
 import { useRef, useState } from "react";
+import { formatHeaders } from "@/components/common/api";
 import { useFileStore } from "@/stores/file-store";
 
 type Position = "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right";
-
-function getToken(): string {
-  return localStorage.getItem("stirling-token") || "";
-}
 
 export function WatermarkImageSettings() {
   const { files, processing, error, setProcessing, setError, setProcessedUrl, setSizes, setJobId } =
@@ -35,7 +32,7 @@ export function WatermarkImageSettings() {
 
       const res = await fetch("/api/v1/tools/watermark-image", {
         method: "POST",
-        headers: { Authorization: `Bearer ${getToken()}` },
+        headers: formatHeaders({}),
         body: formData,
       });
 

--- a/apps/web/src/hooks/use-tool-processor.ts
+++ b/apps/web/src/hooks/use-tool-processor.ts
@@ -1,9 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { formatHeaders } from "@/components/common/api";
 import { useFileStore } from "@/stores/file-store";
-
-function getToken(): string {
-  return localStorage.getItem("stirling-token") || "";
-}
 
 interface ProcessResult {
   jobId: string;
@@ -212,10 +209,9 @@ export function useToolProcessor(toolId: string) {
       };
 
       xhr.open("POST", `/api/v1/tools/${toolId}`);
-      const token = getToken();
-      if (token) {
-        xhr.setRequestHeader("Authorization", `Bearer ${token}`);
-      }
+      formatHeaders({}).forEach((value, key) => {
+        xhr.setRequestHeader(key, value);
+      });
       xhr.send(formData);
     },
     [toolId, isAiTool, setProcessing, setError, setProcessedUrl, setSizes, setJobId],
@@ -282,10 +278,9 @@ export function useToolProcessor(toolId: string) {
       formData.append("clientJobId", clientJobId);
 
       try {
-        const token = getToken();
         const response = await fetch(`/api/v1/tools/${toolId}/batch`, {
           method: "POST",
-          headers: token ? { Authorization: `Bearer ${token}` } : {},
+          headers: formatHeaders({}),
           body: formData,
         });
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,3 +1,5 @@
+import { formatHeaders } from "@/components/common/api";
+
 const API_BASE = "/api";
 
 async function throwWithMessage(res: Response): Promise<never> {
@@ -14,7 +16,7 @@ async function throwWithMessage(res: Response): Promise<never> {
 
 export async function apiGet<T>(path: string): Promise<T> {
   const res = await fetch(`${API_BASE}${path}`, {
-    headers: { Authorization: `Bearer ${getToken()}` },
+    headers: formatHeaders({}),
   });
   if (!res.ok) await throwWithMessage(res);
   return res.json();
@@ -23,10 +25,7 @@ export async function apiGet<T>(path: string): Promise<T> {
 export async function apiPost<T>(path: string, body?: unknown): Promise<T> {
   const res = await fetch(`${API_BASE}${path}`, {
     method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${getToken()}`,
-    },
+    headers: formatHeaders({ "Content-Type": "application/json" }),
     body: body ? JSON.stringify(body) : undefined,
   });
   if (!res.ok) await throwWithMessage(res);
@@ -36,10 +35,7 @@ export async function apiPost<T>(path: string, body?: unknown): Promise<T> {
 export async function apiPut<T>(path: string, body?: unknown): Promise<T> {
   const res = await fetch(`${API_BASE}${path}`, {
     method: "PUT",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${getToken()}`,
-    },
+    headers: formatHeaders({ "Content-Type": "application/json" }),
     body: body ? JSON.stringify(body) : undefined,
   });
   if (!res.ok) await throwWithMessage(res);
@@ -49,16 +45,10 @@ export async function apiPut<T>(path: string, body?: unknown): Promise<T> {
 export async function apiDelete<T>(path: string): Promise<T> {
   const res = await fetch(`${API_BASE}${path}`, {
     method: "DELETE",
-    headers: {
-      Authorization: `Bearer ${getToken()}`,
-    },
+    headers: formatHeaders({}),
   });
   if (!res.ok) await throwWithMessage(res);
   return res.json();
-}
-
-function getToken(): string {
-  return localStorage.getItem("stirling-token") || "";
 }
 
 export function setToken(token: string) {
@@ -79,7 +69,7 @@ export async function apiUpload(files: File[]): Promise<{
   for (const f of files) formData.append("files", f);
   const res = await fetch("/api/v1/upload", {
     method: "POST",
-    headers: { Authorization: `Bearer ${getToken()}` },
+    headers: formatHeaders({}),
     body: formData,
   });
   if (!res.ok) throw new Error(`Upload failed: ${res.status}`);
@@ -141,7 +131,7 @@ export async function apiUploadUserFiles(
   for (const f of files) formData.append("files", f);
   const res = await fetch("/api/v1/files/upload", {
     method: "POST",
-    headers: { Authorization: `Bearer ${getToken()}` },
+    headers: formatHeaders({}),
     body: formData,
   });
   if (!res.ok) throw new Error(`Upload failed: ${res.status}`);
@@ -151,10 +141,7 @@ export async function apiUploadUserFiles(
 export async function apiDeleteUserFiles(ids: string[]): Promise<{ deleted: number }> {
   const res = await fetch("/api/v1/files", {
     method: "DELETE",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${getToken()}`,
-    },
+    headers: formatHeaders({ "Content-Type": "application/json" }),
     body: JSON.stringify({ ids }),
   });
   if (!res.ok) throw new Error(`Delete failed: ${res.status}`);
@@ -171,7 +158,7 @@ export function getFileDownloadUrl(id: string): string {
 
 export async function apiDownloadBlob(jobId: string, filename: string): Promise<Blob> {
   const res = await fetch(getDownloadUrl(jobId, filename), {
-    headers: { Authorization: `Bearer ${getToken()}` },
+    headers: formatHeaders({}),
   });
   if (!res.ok) throw new Error(`Download failed: ${res.status}`);
   return res.blob();

--- a/apps/web/src/pages/automate-page.tsx
+++ b/apps/web/src/pages/automate-page.tsx
@@ -1,5 +1,6 @@
 import { Play, Trash2, Workflow } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
+import { formatHeaders } from "@/components/common/api";
 import { AppLayout } from "@/components/layout/app-layout";
 import { PipelineBuilder, type PipelineStep } from "@/components/tools/pipeline-builder";
 
@@ -9,10 +10,6 @@ interface SavedPipeline {
   description: string | null;
   steps: Array<{ toolId: string; settings: Record<string, unknown> }>;
   createdAt: string;
-}
-
-function getToken(): string {
-  return localStorage.getItem("stirling-token") || "";
 }
 
 export function AutomatePage() {
@@ -32,7 +29,7 @@ export function AutomatePage() {
   const loadPipelines = useCallback(async () => {
     try {
       const res = await fetch("/api/v1/pipeline/list", {
-        headers: { Authorization: `Bearer ${getToken()}` },
+        headers: formatHeaders({}),
       });
       if (res.ok) {
         const data = await res.json();
@@ -54,10 +51,7 @@ export function AutomatePage() {
       try {
         const res = await fetch("/api/v1/pipeline/save", {
           method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${getToken()}`,
-          },
+          headers: formatHeaders({ "Content-Type": "application/json" }),
           body: JSON.stringify({
             name,
             description: description || undefined,
@@ -85,7 +79,7 @@ export function AutomatePage() {
       try {
         await fetch(`/api/v1/pipeline/${id}`, {
           method: "DELETE",
-          headers: { Authorization: `Bearer ${getToken()}` },
+          headers: formatHeaders({}),
         });
         await loadPipelines();
       } catch {
@@ -116,7 +110,7 @@ export function AutomatePage() {
 
         const res = await fetch("/api/v1/pipeline/execute", {
           method: "POST",
-          headers: { Authorization: `Bearer ${getToken()}` },
+          headers: formatHeaders({}),
           body: formData,
         });
 


### PR DESCRIPTION
# What this does?

- Replace duplicated getToken + Bearer header logic with formatHeaders from components/common/api.
- Skips Authorization header when token is empty to avoid proxy forward-auth issues. Apply via fetch headers or XHR forEach.

# Why?

I'm trying to set up this drilling image behind Caddy using Authelia, which uses forward_auth. However, given that we are sending a blank bearer token, what ends up happening is that the web page throws four ones when trying to hit the API and prompts for a username and password using a dialog.

By swapping this to not send the bearer header if there is no token, we can avoid this issue altogether.

I implemented the first couple myself and then migrated the rest using a prompt.