### PR TITLE
fix(docker): use pnpm exec instead of npx for airgapped environments

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -234,4 +234,4 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
 
 # tini as PID 1 for zombie reaping + signal forwarding
 ENTRYPOINT ["tini", "--", "entrypoint.sh"]
-CMD ["npx", "tsx", "apps/api/src/index.ts"]
+CMD ["pnpm", "exec", "tsx", "apps/api/src/index.ts"]


### PR DESCRIPTION
## Summary

- Replaces `npx tsx` with `pnpm exec tsx` in the production Dockerfile CMD
- `npx` attempts to reach the npm registry even when `tsx` is installed locally as a production dependency, causing ECONNRESET crashes in airgapped/offline environments
- `pnpm exec` resolves binaries from local `node_modules` only, with no network calls

Closes #29

## Test plan

- [x] All 398 unit tests pass
- [x] All 391 integration tests pass
- [x] TypeScript typecheck passes
- [x] Biome lint passes
- [x] Dockerfile syntax validated via `docker buildx --check`