### PR TITLE
fix: prevent admin escalation when AUTH_ENABLED=false

### DIFF
--- a/apps/api/src/plugins/auth.ts
+++ b/apps/api/src/plugins/auth.ts
@@ -659,16 +659,14 @@ function isPublicRoute(url: string): boolean {
 
 export async function authMiddleware(app: FastifyInstance): Promise<void> {
   app.addHook("preHandler", async (request: FastifyRequest, reply: FastifyReply) => {
-    // When auth is disabled, attach the first admin user so requireAuth/requireAdmin pass
+    // When auth is disabled, attach a synthetic non-admin user so tools work
+    // but admin-only routes (user management, settings write, etc.) stay locked
     if (!env.AUTH_ENABLED) {
-      const adminUser = db.select().from(schema.users).where(eq(schema.users.role, "admin")).get();
-      if (adminUser) {
-        (request as FastifyRequest & { user?: AuthUser }).user = {
-          id: adminUser.id,
-          username: adminUser.username,
-          role: "admin",
-        };
-      }
+      (request as FastifyRequest & { user?: AuthUser }).user = {
+        id: "anonymous",
+        username: "anonymous",
+        role: "user",
+      };
       return;
     }
 

--- a/apps/web/src/hooks/use-auth.ts
+++ b/apps/web/src/hooks/use-auth.ts
@@ -11,19 +11,12 @@ interface AuthState {
   permissions: string[];
 }
 
-const ALL_PERMISSIONS = [
+const USER_PERMISSIONS = [
   "tools:use",
   "files:own",
-  "files:all",
   "apikeys:own",
-  "apikeys:all",
   "pipelines:own",
-  "pipelines:all",
   "settings:read",
-  "settings:write",
-  "users:manage",
-  "teams:manage",
-  "branding:manage",
 ];
 
 export function useAuth() {
@@ -51,8 +44,8 @@ export function useAuth() {
               authEnabled: false,
               isAuthenticated: true,
               mustChangePassword: false,
-              role: "admin",
-              permissions: ALL_PERMISSIONS,
+              role: "user",
+              permissions: USER_PERMISSIONS,
             });
           return;
         }


### PR DESCRIPTION
## Summary

Fixes #72 — when `AUTH_ENABLED=false`, every visitor was silently granted full admin access (user management, settings write, teams, branding, feature installation).

**Root cause:** Two independent layers both hardcoded `role: "admin"` when auth was disabled:
- **Backend** (`apps/api/src/plugins/auth.ts`): The auth middleware queried the DB for the first admin user and attached it to every request
- **Frontend** (`apps/web/src/hooks/use-auth.ts`): The `useAuth` hook set `role: "admin"` with all 12 permissions

**Fix:** Both layers now use `role: "user"` with user-level permissions (`tools:use`, `files:own`, `apikeys:own`, `pipelines:own`, `settings:read`). This preserves the "no login required" UX while blocking admin-only operations.

## What works with AUTH_ENABLED=false (unchanged)
- All image tools (resize, crop, convert, OCR, etc.)
- File upload/download
- Pipeline execution
- Settings read
- API key management (own keys)

## What is now correctly blocked
- User management (list/create/delete users) → 403
- Settings write → 403
- Team management → 403
- Branding/logo management → 403
- Feature installation → 403
- User registration → 403

## Test plan
- [x] `pnpm typecheck` — zero errors
- [x] `pnpm lint` — zero warnings
- [x] `pnpm test:unit` — 434/437 pass (3 pre-existing failures in `validateImageBuffer`, unrelated)
- [x] `pnpm test:integration` — 386/391 pass (5 pre-existing failures in pipeline/branding validation, unrelated)
- [x] Docker build + run with `AUTH_ENABLED=false` on port 11349
- [x] Verified admin endpoints return `403 FORBIDDEN`
- [x] Verified tool operations succeed (resize with `Untitled.jpg`, batch upload with SVG)
- [x] permissions.test.ts: 28/28 pass
- [x] teams.test.ts: 21/21 pass