### PR TITLE
fix: auto-fallback from CodeFormer to GFPGAN in face enhancement

### DIFF
--- a/packages/ai/python/enhance_faces.py
+++ b/packages/ai/python/enhance_faces.py
@@ -317,12 +317,11 @@ def main():
                     model_used = "codeformer"
                 except Exception as e:
                     import traceback
-                    print(f"[enhance-faces] CodeFormer failed: {e}", file=sys.stderr, flush=True)
+                    print(f"[enhance-faces] CodeFormer failed, falling back to GFPGAN: {e}", file=sys.stderr, flush=True)
                     traceback.print_exc(file=sys.stderr)
-                    raise RuntimeError(
-                        f"CodeFormer is not available: {e}. "
-                        "Install the face-enhance feature or use model=gfpgan."
-                    ) from e
+                    emit_progress(50, "Falling back to GFPGAN")
+                    enhanced = enhance_with_gfpgan(img_array, only_center_face)
+                    model_used = "gfpgan"
 
         finally:
             # Restore stdout after ALL AI processing


### PR DESCRIPTION
## Summary
- When face enhancement model is set to `auto`, CodeFormer failure previously threw an error telling users to manually switch to GFPGAN
- Now automatically falls back to GFPGAN, matching the graceful degradation pattern already used in OCR's fallback chain
- Users see a "Falling back to GFPGAN" progress update; failure details are still logged to stderr for debugging

## Test plan
- [ ] Run face enhancement with `model=auto` in Docker where CodeFormer is unavailable — should fall back to GFPGAN and succeed
- [ ] Run face enhancement with `model=auto` where CodeFormer works — should use CodeFormer as before
- [ ] Run face enhancement with `model=gfpgan` explicitly — unchanged behavior
- [ ] Run face enhancement with `model=codeformer` explicitly when unavailable — should still error (no silent fallback for explicit choice)