### PR TITLE
feat: production-grade RBAC with editor role, custom roles, API key scoping, and audit log

### DIFF
--- a/apps/api/drizzle/0006_rbac_revamp.sql
+++ b/apps/api/drizzle/0006_rbac_revamp.sql
@@ -1,0 +1,19 @@
+-- Add permissions column to api_keys for scoped API keys
+ALTER TABLE `api_keys` ADD COLUMN `permissions` text;
+--> statement-breakpoint
+-- Create audit_log table for queryable audit trail
+CREATE TABLE IF NOT EXISTS `audit_log` (
+  `id` text PRIMARY KEY NOT NULL,
+  `actor_id` text REFERENCES `users`(`id`) ON DELETE SET NULL,
+  `actor_username` text NOT NULL,
+  `action` text NOT NULL,
+  `target_type` text,
+  `target_id` text,
+  `details` text,
+  `ip_address` text,
+  `created_at` integer NOT NULL DEFAULT (unixepoch())
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `audit_log_action_idx` ON `audit_log` (`action`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `audit_log_created_at_idx` ON `audit_log` (`created_at`);

--- a/apps/api/drizzle/0007_custom_roles.sql
+++ b/apps/api/drizzle/0007_custom_roles.sql
@@ -1,0 +1,19 @@
+-- Create roles table
+CREATE TABLE IF NOT EXISTS `roles` (
+  `id` text PRIMARY KEY NOT NULL,
+  `name` text NOT NULL,
+  `description` text NOT NULL DEFAULT '',
+  `permissions` text NOT NULL,
+  `is_builtin` integer NOT NULL DEFAULT 0,
+  `created_by` text REFERENCES `users`(`id`) ON DELETE SET NULL,
+  `created_at` integer NOT NULL DEFAULT (unixepoch()),
+  `updated_at` integer NOT NULL DEFAULT (unixepoch())
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `roles_name_unique` ON `roles` (`name`);
+--> statement-breakpoint
+-- Seed built-in roles
+INSERT OR IGNORE INTO `roles` (`id`, `name`, `description`, `permissions`, `is_builtin`) VALUES
+  ('builtin-admin', 'admin', 'Full administrative access', '["tools:use","files:own","files:all","apikeys:own","apikeys:all","pipelines:own","pipelines:all","settings:read","settings:write","users:manage","teams:manage","branding:manage","features:manage","system:health","audit:read"]', 1),
+  ('builtin-editor', 'editor', 'Can see all files and pipelines', '["tools:use","files:own","files:all","apikeys:own","pipelines:own","pipelines:all","settings:read"]', 1),
+  ('builtin-user', 'user', 'Basic tool access', '["tools:use","files:own","apikeys:own","pipelines:own","settings:read"]', 1);

--- a/apps/api/drizzle/0008_api_key_expiration.sql
+++ b/apps/api/drizzle/0008_api_key_expiration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `api_keys` ADD COLUMN `expires_at` integer;

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1745366400000,
       "tag": "0006_rbac_revamp",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1745366500000,
+      "tag": "0007_custom_roles",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1745366500000,
       "tag": "0007_custom_roles",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1745366600000,
+      "tag": "0008_api_key_expiration",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1774700000000,
       "tag": "0005_add_teams_table",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1745366400000,
+      "tag": "0006_rbac_revamp",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -4,9 +4,7 @@ export const users = sqliteTable("users", {
   id: text("id").primaryKey(),
   username: text("username").notNull().unique(),
   passwordHash: text("password_hash").notNull(),
-  role: text("role", { enum: ["admin", "editor", "user"] })
-    .notNull()
-    .default("user"),
+  role: text("role").notNull().default("user"),
   team: text("team").notNull().default("Default"),
   mustChangePassword: integer("must_change_password", { mode: "boolean" }).notNull().default(true),
   createdAt: integer("created_at", { mode: "timestamp" })
@@ -97,6 +95,21 @@ export const auditLog = sqliteTable("audit_log", {
   details: text("details"),
   ipAddress: text("ip_address"),
   createdAt: integer("created_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+});
+
+export const roles = sqliteTable("roles", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull().unique(),
+  description: text("description").notNull().default(""),
+  permissions: text("permissions").notNull(),
+  isBuiltin: integer("is_builtin", { mode: "boolean" }).notNull().default(false),
+  createdBy: text("created_by").references(() => users.id, { onDelete: "set null" }),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+  updatedAt: integer("updated_at", { mode: "timestamp" })
     .notNull()
     .$defaultFn(() => new Date()),
 });

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -4,7 +4,7 @@ export const users = sqliteTable("users", {
   id: text("id").primaryKey(),
   username: text("username").notNull().unique(),
   passwordHash: text("password_hash").notNull(),
-  role: text("role", { enum: ["admin", "user"] })
+  role: text("role", { enum: ["admin", "editor", "user"] })
     .notNull()
     .default("user"),
   team: text("team").notNull().default("Default"),
@@ -69,6 +69,7 @@ export const apiKeys = sqliteTable("api_keys", {
   keyHash: text("key_hash").notNull(),
   keyPrefix: text("key_prefix"),
   name: text("name").notNull().default("Default API Key"),
+  permissions: text("permissions"),
   createdAt: integer("created_at", { mode: "timestamp" })
     .notNull()
     .$defaultFn(() => new Date()),
@@ -81,6 +82,20 @@ export const pipelines = sqliteTable("pipelines", {
   name: text("name").notNull(),
   description: text("description"),
   steps: text("steps").notNull(), // JSON array of { toolId, settings }
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+});
+
+export const auditLog = sqliteTable("audit_log", {
+  id: text("id").primaryKey(),
+  actorId: text("actor_id").references(() => users.id, { onDelete: "set null" }),
+  actorUsername: text("actor_username").notNull(),
+  action: text("action").notNull(),
+  targetType: text("target_type"),
+  targetId: text("target_id"),
+  details: text("details"),
+  ipAddress: text("ip_address"),
   createdAt: integer("created_at", { mode: "timestamp" })
     .notNull()
     .$defaultFn(() => new Date()),

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -72,6 +72,7 @@ export const apiKeys = sqliteTable("api_keys", {
     .notNull()
     .$defaultFn(() => new Date()),
   lastUsedAt: integer("last_used_at", { mode: "timestamp" }),
+  expiresAt: integer("expires_at", { mode: "timestamp" }),
 });
 
 export const pipelines = sqliteTable("pipelines", {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -22,6 +22,7 @@ import { registerFeatureRoutes } from "./routes/features.js";
 import { fileRoutes } from "./routes/files.js";
 import { registerPipelineRoutes } from "./routes/pipeline.js";
 import { recoverStaleJobs, registerProgressRoutes } from "./routes/progress.js";
+import { rolesRoutes } from "./routes/roles.js";
 import { settingsRoutes } from "./routes/settings.js";
 import { teamsRoutes } from "./routes/teams.js";
 import { registerToolRoutes } from "./routes/tools/index.js";
@@ -138,6 +139,9 @@ await teamsRoutes(app);
 
 // Audit log routes
 await auditLogRoutes(app);
+
+// Roles management routes
+await rolesRoutes(app);
 
 // API docs (Scalar)
 await docsRoutes(app);

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -14,6 +14,7 @@ import { authMiddleware, authRoutes, ensureDefaultAdmin } from "./plugins/auth.j
 import { registerStatic } from "./plugins/static.js";
 import { registerUpload } from "./plugins/upload.js";
 import { apiKeyRoutes } from "./routes/api-keys.js";
+import { auditLogRoutes } from "./routes/audit-log.js";
 import { registerBatchRoutes } from "./routes/batch.js";
 import { brandingRoutes } from "./routes/branding.js";
 import { docsRoutes } from "./routes/docs.js";
@@ -134,6 +135,9 @@ await brandingRoutes(app);
 
 // Teams routes
 await teamsRoutes(app);
+
+// Audit log routes
+await auditLogRoutes(app);
 
 // API docs (Scalar)
 await docsRoutes(app);

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -9,7 +9,8 @@ import { runMigrations } from "./db/migrate.js";
 import { startCleanupCron } from "./lib/cleanup.js";
 import { ensureAiDirs, recoverInterruptedInstalls } from "./lib/feature-status.js";
 import { shutdownWorkerPool } from "./lib/worker-pool.js";
-import { authMiddleware, authRoutes, ensureDefaultAdmin, requireAdmin } from "./plugins/auth.js";
+import { requirePermission } from "./permissions.js";
+import { authMiddleware, authRoutes, ensureDefaultAdmin } from "./plugins/auth.js";
 import { registerStatic } from "./plugins/static.js";
 import { registerUpload } from "./plugins/upload.js";
 import { apiKeyRoutes } from "./routes/api-keys.js";
@@ -157,7 +158,7 @@ app.get("/api/v1/health", async (_request, reply) => {
 
 // Admin health check (full diagnostics)
 app.get("/api/v1/admin/health", async (request, reply) => {
-  const admin = requireAdmin(request, reply);
+  const admin = requirePermission("system:health")(request, reply);
   if (!admin) return;
 
   let dbOk = false;

--- a/apps/api/src/lib/audit.ts
+++ b/apps/api/src/lib/audit.ts
@@ -1,4 +1,6 @@
+import { randomUUID } from "node:crypto";
 import type { FastifyBaseLogger } from "fastify";
+import { db, schema } from "../db/index.js";
 
 type AuditEvent =
   | "LOGIN_SUCCESS"
@@ -12,13 +14,16 @@ type AuditEvent =
   | "FILE_UPLOADED"
   | "FILE_DELETED"
   | "API_KEY_CREATED"
-  | "API_KEY_DELETED";
+  | "API_KEY_DELETED"
+  | "ROLE_CREATED"
+  | "ROLE_UPDATED"
+  | "ROLE_DELETED"
+  | "SETTINGS_UPDATED";
 
 /**
  * Emit a structured audit log entry for security-relevant events.
  *
- * Logs are written at INFO level with `audit: true` so they can be
- * filtered by log aggregators (e.g. `jq 'select(.audit)'`).
+ * Dual-writes: structured stdout log (for aggregators) + SQLite row.
  */
 export function auditLog(
   logger: FastifyBaseLogger,
@@ -26,4 +31,41 @@ export function auditLog(
   details: Record<string, unknown> = {},
 ): void {
   logger.info({ audit: true, event, ...details }, `[AUDIT] ${event}`);
+
+  const actorId = (details.userId as string) ?? (details.adminId as string) ?? null;
+  const actorUsername = (details.username as string) ?? (details.newUsername as string) ?? "system";
+  const targetId = (details.targetUserId as string) ?? (details.keyId as string) ?? null;
+  const targetType = deriveTargetType(event);
+
+  try {
+    db.insert(schema.auditLog)
+      .values({
+        id: randomUUID(),
+        actorId,
+        actorUsername,
+        action: event,
+        targetType,
+        targetId,
+        details: JSON.stringify(details),
+        ipAddress: null,
+      })
+      .run();
+  } catch {
+    logger.warn({ event }, "Failed to write audit log to DB");
+  }
+}
+
+function deriveTargetType(event: AuditEvent): string | null {
+  if (
+    event.startsWith("USER_") ||
+    event.startsWith("LOGIN") ||
+    event.startsWith("PASSWORD") ||
+    event === "LOGOUT"
+  )
+    return "user";
+  if (event.startsWith("API_KEY")) return "api_key";
+  if (event.startsWith("FILE")) return "file";
+  if (event.startsWith("ROLE")) return "role";
+  if (event === "SETTINGS_UPDATED") return "setting";
+  return null;
 }

--- a/apps/api/src/permissions.ts
+++ b/apps/api/src/permissions.ts
@@ -1,5 +1,7 @@
 import type { Permission, Role } from "@ashim/shared";
+import { eq } from "drizzle-orm";
 import type { FastifyReply, FastifyRequest } from "fastify";
+import { db, schema } from "./db/index.js";
 import { type AuthUser, getAuthUser } from "./plugins/auth.js";
 
 const ROLE_PERMISSIONS: Record<Role, Permission[]> = {
@@ -32,16 +34,31 @@ const ROLE_PERMISSIONS: Record<Role, Permission[]> = {
   user: ["tools:use", "files:own", "apikeys:own", "pipelines:own", "settings:read"],
 };
 
-export function getPermissions(role: Role): Permission[] {
-  return ROLE_PERMISSIONS[role] ?? [];
+export function getPermissions(role: Role | string): Permission[] {
+  if (role in ROLE_PERMISSIONS) {
+    return ROLE_PERMISSIONS[role as Role];
+  }
+  try {
+    const customRole = db
+      .select()
+      .from(schema.roles)
+      .where(eq(schema.roles.name, role as string))
+      .get();
+    if (customRole) {
+      return JSON.parse(customRole.permissions) as Permission[];
+    }
+  } catch {
+    // DB not yet available during early startup
+  }
+  return [];
 }
 
-export function hasPermission(role: Role, permission: Permission): boolean {
+export function hasPermission(role: Role | string, permission: Permission): boolean {
   return getPermissions(role).includes(permission);
 }
 
 export function hasEffectivePermission(user: AuthUser, permission: Permission): boolean {
-  if (!hasPermission(user.role as Role, permission)) return false;
+  if (!hasPermission(user.role, permission)) return false;
   if (user.apiKeyPermissions) {
     return user.apiKeyPermissions.includes(permission);
   }

--- a/apps/api/src/permissions.ts
+++ b/apps/api/src/permissions.ts
@@ -1,6 +1,6 @@
 import type { Permission, Role } from "@ashim/shared";
 import type { FastifyReply, FastifyRequest } from "fastify";
-import { getAuthUser } from "./plugins/auth.js";
+import { type AuthUser, getAuthUser } from "./plugins/auth.js";
 
 const ROLE_PERMISSIONS: Record<Role, Permission[]> = {
   admin: [
@@ -40,6 +40,14 @@ export function hasPermission(role: Role, permission: Permission): boolean {
   return getPermissions(role).includes(permission);
 }
 
+export function hasEffectivePermission(user: AuthUser, permission: Permission): boolean {
+  if (!hasPermission(user.role as Role, permission)) return false;
+  if (user.apiKeyPermissions) {
+    return user.apiKeyPermissions.includes(permission);
+  }
+  return true;
+}
+
 export function requirePermission(permission: Permission) {
   return (request: FastifyRequest, reply: FastifyReply) => {
     const user = getAuthUser(request);
@@ -47,7 +55,7 @@ export function requirePermission(permission: Permission) {
       reply.status(401).send({ error: "Authentication required", code: "AUTH_REQUIRED" });
       return null;
     }
-    if (!hasPermission(user.role as Role, permission)) {
+    if (!hasEffectivePermission(user, permission)) {
       reply.status(403).send({ error: "Insufficient permissions", code: "FORBIDDEN" });
       return null;
     }
@@ -66,7 +74,7 @@ export function requireOwnershipOrPermission(
     reply.status(401).send({ error: "Authentication required", code: "AUTH_REQUIRED" });
     return null;
   }
-  if (resourceUserId !== user.id && !hasPermission(user.role as Role, allPermission)) {
+  if (resourceUserId !== user.id && !hasEffectivePermission(user, allPermission)) {
     return null;
   }
   return user;

--- a/apps/api/src/permissions.ts
+++ b/apps/api/src/permissions.ts
@@ -16,6 +16,18 @@ const ROLE_PERMISSIONS: Record<Role, Permission[]> = {
     "users:manage",
     "teams:manage",
     "branding:manage",
+    "features:manage",
+    "system:health",
+    "audit:read",
+  ],
+  editor: [
+    "tools:use",
+    "files:own",
+    "files:all",
+    "apikeys:own",
+    "pipelines:own",
+    "pipelines:all",
+    "settings:read",
   ],
   user: ["tools:use", "files:own", "apikeys:own", "pipelines:own", "settings:read"],
 };
@@ -41,4 +53,21 @@ export function requirePermission(permission: Permission) {
     }
     return user;
   };
+}
+
+export function requireOwnershipOrPermission(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  resourceUserId: string | null,
+  allPermission: Permission,
+) {
+  const user = getAuthUser(request);
+  if (!user) {
+    reply.status(401).send({ error: "Authentication required", code: "AUTH_REQUIRED" });
+    return null;
+  }
+  if (resourceUserId !== user.id && !hasPermission(user.role as Role, allPermission)) {
+    return null;
+  }
+  return user;
 }

--- a/apps/api/src/plugins/auth.ts
+++ b/apps/api/src/plugins/auth.ts
@@ -14,7 +14,7 @@ const scryptAsync = promisify(scrypt);
 export interface AuthUser {
   id: string;
   username: string;
-  role: "admin" | "editor" | "user";
+  role: string;
   apiKeyPermissions?: string[];
 }
 
@@ -206,7 +206,7 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
           username: user.username,
           role: user.role,
           mustChangePassword: env.SKIP_MUST_CHANGE_PASSWORD ? false : user.mustChangePassword,
-          permissions: getPermissions(user.role as "admin" | "editor" | "user"),
+          permissions: getPermissions(user.role),
           teamName: teamRow?.name ?? user.team,
         },
         expiresAt: expiresAt.toISOString(),
@@ -254,7 +254,7 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
         username: user.username,
         role: user.role,
         mustChangePassword: env.SKIP_MUST_CHANGE_PASSWORD ? false : user.mustChangePassword,
-        permissions: getPermissions(user.role as "admin" | "editor" | "user"),
+        permissions: getPermissions(user.role),
       },
       expiresAt: session.expiresAt.toISOString(),
     });
@@ -390,10 +390,22 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
       });
     }
 
-    const validRoles = ["admin", "editor", "user"] as const;
-    const role = validRoles.includes(body.role as any)
-      ? (body.role as "admin" | "editor" | "user")
-      : "user";
+    const validBuiltinRoles = ["admin", "editor", "user"];
+    let role: string = "user";
+    if (body.role) {
+      if (validBuiltinRoles.includes(body.role)) {
+        role = body.role;
+      } else {
+        const customRole = db
+          .select()
+          .from(schema.roles)
+          .where(eq(schema.roles.name, body.role))
+          .get();
+        if (customRole) {
+          role = body.role;
+        }
+      }
+    }
 
     // Escalation prevention
     const roleHierarchy: Record<string, number> = { admin: 3, editor: 2, user: 1 };
@@ -504,7 +516,7 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
         return reply.status(404).send({ error: "User not found", code: "NOT_FOUND" });
       }
 
-      const updates: { role?: "admin" | "editor" | "user"; team?: string; updatedAt: Date } = {
+      const updates: { role?: string; team?: string; updatedAt: Date } = {
         updatedAt: new Date(),
       };
 
@@ -521,31 +533,37 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
         }
       }
 
-      if (body?.role === "admin" || body?.role === "editor" || body?.role === "user") {
-        // Prevent removing your own admin role
-        if (id === admin.id && body.role !== "admin") {
-          return reply.status(400).send({
-            error: "Cannot remove your own admin role",
-            code: "SELF_DEMOTE",
-          });
-        }
-
-        // Last admin protection
-        if (user.role === "admin" && body?.role !== "admin") {
-          const adminCount = db
-            .select({ count: sql<number>`COUNT(*)` })
-            .from(schema.users)
-            .where(eq(schema.users.role, "admin"))
-            .get();
-          if (adminCount && adminCount.count <= 1) {
+      if (body?.role) {
+        const validBuiltinRoles = ["admin", "editor", "user"];
+        const isValid =
+          validBuiltinRoles.includes(body.role) ||
+          db.select().from(schema.roles).where(eq(schema.roles.name, body.role)).get();
+        if (isValid) {
+          // Prevent removing your own admin role
+          if (id === admin.id && body.role !== "admin") {
             return reply.status(400).send({
-              error: "Cannot demote the last admin",
-              code: "LAST_ADMIN",
+              error: "Cannot remove your own admin role",
+              code: "SELF_DEMOTE",
             });
           }
-        }
 
-        updates.role = body.role as "admin" | "editor" | "user";
+          // Last admin protection
+          if (user.role === "admin" && body.role !== "admin") {
+            const adminCount = db
+              .select({ count: sql<number>`COUNT(*)` })
+              .from(schema.users)
+              .where(eq(schema.users.role, "admin"))
+              .get();
+            if (adminCount && adminCount.count <= 1) {
+              return reply.status(400).send({
+                error: "Cannot demote the last admin",
+                code: "LAST_ADMIN",
+              });
+            }
+          }
+
+          updates.role = body.role;
+        }
       }
 
       if (typeof body?.team === "string" && body.team.trim()) {
@@ -776,7 +794,7 @@ export async function authMiddleware(app: FastifyInstance): Promise<void> {
               (request as FastifyRequest & { user?: AuthUser }).user = {
                 id: apiUser.id,
                 username: apiUser.username,
-                role: apiUser.role as "admin" | "editor" | "user",
+                role: apiUser.role,
                 apiKeyPermissions: keyPermissions,
               };
               return;
@@ -802,7 +820,7 @@ export async function authMiddleware(app: FastifyInstance): Promise<void> {
     (request as FastifyRequest & { user?: AuthUser }).user = {
       id: user.id,
       username: user.username,
-      role: user.role as "admin" | "editor" | "user",
+      role: user.role,
     };
 
     // Enforce mustChangePassword — block non-auth API calls

--- a/apps/api/src/plugins/auth.ts
+++ b/apps/api/src/plugins/auth.ts
@@ -769,6 +769,11 @@ export async function authMiddleware(app: FastifyInstance): Promise<void> {
         for (const key of keysToCheck) {
           const matches = await verifyPassword(token, key.keyHash);
           if (matches) {
+            // Check expiration
+            if (key.expiresAt && key.expiresAt < new Date()) {
+              // Key expired — skip it
+              continue;
+            }
             // Backfill prefix for legacy keys
             if (!key.keyPrefix) {
               db.update(schema.apiKeys)

--- a/apps/api/src/plugins/auth.ts
+++ b/apps/api/src/plugins/auth.ts
@@ -1,6 +1,6 @@
 import { createHash, randomBytes, randomUUID, scrypt, timingSafeEqual } from "node:crypto";
 import { promisify } from "node:util";
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { env } from "../config.js";
 import { db, schema } from "../db/index.js";
@@ -395,6 +395,17 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
       ? (body.role as "admin" | "editor" | "user")
       : "user";
 
+    // Escalation prevention
+    const roleHierarchy: Record<string, number> = { admin: 3, editor: 2, user: 1 };
+    const actorLevel = roleHierarchy[admin.role] ?? 0;
+    const targetLevel = roleHierarchy[role] ?? 0;
+    if (targetLevel > actorLevel) {
+      return reply.status(403).send({
+        error: "Cannot create a user with a higher role than your own",
+        code: "ESCALATION_DENIED",
+      });
+    }
+
     // Resolve team — frontend sends team name (e.g. "Default"), not ID
     const requestedTeam = (body as { team?: string }).team;
     let teamId: string;
@@ -497,6 +508,19 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
         updatedAt: new Date(),
       };
 
+      // Escalation prevention
+      if (body?.role) {
+        const roleHierarchy: Record<string, number> = { admin: 3, editor: 2, user: 1 };
+        const actorLevel = roleHierarchy[admin.role] ?? 0;
+        const targetLevel = roleHierarchy[body.role] ?? 0;
+        if (targetLevel > actorLevel) {
+          return reply.status(403).send({
+            error: "Cannot assign a role higher than your own",
+            code: "ESCALATION_DENIED",
+          });
+        }
+      }
+
       if (body?.role === "admin" || body?.role === "editor" || body?.role === "user") {
         // Prevent removing your own admin role
         if (id === admin.id && body.role !== "admin") {
@@ -505,6 +529,22 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
             code: "SELF_DEMOTE",
           });
         }
+
+        // Last admin protection
+        if (user.role === "admin" && body?.role !== "admin") {
+          const adminCount = db
+            .select({ count: sql<number>`COUNT(*)` })
+            .from(schema.users)
+            .where(eq(schema.users.role, "admin"))
+            .get();
+          if (adminCount && adminCount.count <= 1) {
+            return reply.status(400).send({
+              error: "Cannot demote the last admin",
+              code: "LAST_ADMIN",
+            });
+          }
+        }
+
         updates.role = body.role as "admin" | "editor" | "user";
       }
 

--- a/apps/api/src/plugins/auth.ts
+++ b/apps/api/src/plugins/auth.ts
@@ -5,7 +5,7 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { env } from "../config.js";
 import { db, schema } from "../db/index.js";
 import { auditLog } from "../lib/audit.js";
-import { getPermissions } from "../permissions.js";
+import { getPermissions, requirePermission } from "../permissions.js";
 
 const scryptAsync = promisify(scrypt);
 
@@ -14,7 +14,7 @@ const scryptAsync = promisify(scrypt);
 export interface AuthUser {
   id: string;
   username: string;
-  role: "admin" | "user";
+  role: "admin" | "editor" | "user";
 }
 
 const MAX_USERS = env.MAX_USERS;
@@ -205,7 +205,7 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
           username: user.username,
           role: user.role,
           mustChangePassword: env.SKIP_MUST_CHANGE_PASSWORD ? false : user.mustChangePassword,
-          permissions: getPermissions(user.role as "admin" | "user"),
+          permissions: getPermissions(user.role as "admin" | "editor" | "user"),
           teamName: teamRow?.name ?? user.team,
         },
         expiresAt: expiresAt.toISOString(),
@@ -253,7 +253,7 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
         username: user.username,
         role: user.role,
         mustChangePassword: env.SKIP_MUST_CHANGE_PASSWORD ? false : user.mustChangePassword,
-        permissions: getPermissions(user.role as "admin" | "user"),
+        permissions: getPermissions(user.role as "admin" | "editor" | "user"),
       },
       expiresAt: session.expiresAt.toISOString(),
     });
@@ -327,7 +327,7 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
 
   // GET /api/auth/users (admin only)
   app.get("/api/auth/users", async (request: FastifyRequest, reply: FastifyReply) => {
-    const admin = requireAdmin(request, reply);
+    const admin = requirePermission("users:manage")(request, reply);
     if (!admin) return;
 
     const users = db
@@ -357,7 +357,7 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
 
   // POST /api/auth/register (admin only)
   app.post("/api/auth/register", async (request: FastifyRequest, reply: FastifyReply) => {
-    const admin = requireAdmin(request, reply);
+    const admin = requirePermission("users:manage")(request, reply);
     if (!admin) return;
 
     const body = request.body as {
@@ -389,7 +389,10 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
       });
     }
 
-    const role = body.role === "admin" ? "admin" : "user";
+    const validRoles = ["admin", "editor", "user"] as const;
+    const role = validRoles.includes(body.role as any)
+      ? (body.role as "admin" | "editor" | "user")
+      : "user";
 
     // Resolve team — frontend sends team name (e.g. "Default"), not ID
     const requestedTeam = (body as { team?: string }).team;
@@ -477,7 +480,7 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
   app.put(
     "/api/auth/users/:id",
     async (request: FastifyRequest<{ Params: { id: string } }>, reply: FastifyReply) => {
-      const admin = requireAdmin(request, reply);
+      const admin = requirePermission("users:manage")(request, reply);
       if (!admin) return;
 
       const { id } = request.params;
@@ -489,11 +492,11 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
         return reply.status(404).send({ error: "User not found", code: "NOT_FOUND" });
       }
 
-      const updates: { role?: "admin" | "user"; team?: string; updatedAt: Date } = {
+      const updates: { role?: "admin" | "editor" | "user"; team?: string; updatedAt: Date } = {
         updatedAt: new Date(),
       };
 
-      if (body?.role === "admin" || body?.role === "user") {
+      if (body?.role === "admin" || body?.role === "editor" || body?.role === "user") {
         // Prevent removing your own admin role
         if (id === admin.id && body.role !== "admin") {
           return reply.status(400).send({
@@ -501,7 +504,7 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
             code: "SELF_DEMOTE",
           });
         }
-        updates.role = body.role;
+        updates.role = body.role as "admin" | "editor" | "user";
       }
 
       if (typeof body?.team === "string" && body.team.trim()) {
@@ -537,7 +540,7 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
   app.post(
     "/api/auth/users/:id/reset-password",
     async (request: FastifyRequest<{ Params: { id: string } }>, reply: FastifyReply) => {
-      const admin = requireAdmin(request, reply);
+      const admin = requirePermission("users:manage")(request, reply);
       if (!admin) return;
 
       const { id } = request.params;
@@ -591,7 +594,7 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
   app.delete(
     "/api/auth/users/:id",
     async (request: FastifyRequest<{ Params: { id: string } }>, reply: FastifyReply) => {
-      const admin = requireAdmin(request, reply);
+      const admin = requirePermission("users:manage")(request, reply);
       if (!admin) return;
 
       const { id } = request.params;
@@ -729,7 +732,7 @@ export async function authMiddleware(app: FastifyInstance): Promise<void> {
               (request as FastifyRequest & { user?: AuthUser }).user = {
                 id: apiUser.id,
                 username: apiUser.username,
-                role: apiUser.role as "admin" | "user",
+                role: apiUser.role as "admin" | "editor" | "user",
               };
               return;
             }
@@ -754,7 +757,7 @@ export async function authMiddleware(app: FastifyInstance): Promise<void> {
     (request as FastifyRequest & { user?: AuthUser }).user = {
       id: user.id,
       username: user.username,
-      role: user.role as "admin" | "user",
+      role: user.role as "admin" | "editor" | "user",
     };
 
     // Enforce mustChangePassword — block non-auth API calls

--- a/apps/api/src/plugins/auth.ts
+++ b/apps/api/src/plugins/auth.ts
@@ -15,6 +15,7 @@ export interface AuthUser {
   id: string;
   username: string;
   role: "admin" | "editor" | "user";
+  apiKeyPermissions?: string[];
 }
 
 const MAX_USERS = env.MAX_USERS;
@@ -729,10 +730,14 @@ export async function authMiddleware(app: FastifyInstance): Promise<void> {
               .where(eq(schema.users.id, key.userId))
               .get();
             if (apiUser) {
+              const keyPermissions = key.permissions
+                ? JSON.parse(key.permissions as string)
+                : undefined;
               (request as FastifyRequest & { user?: AuthUser }).user = {
                 id: apiUser.id,
                 username: apiUser.username,
                 role: apiUser.role as "admin" | "editor" | "user",
+                apiKeyPermissions: keyPermissions,
               };
               return;
             }

--- a/apps/api/src/routes/api-keys.ts
+++ b/apps/api/src/routes/api-keys.ts
@@ -36,7 +36,8 @@ export async function apiKeyRoutes(app: FastifyInstance): Promise<void> {
     let scopedPermissions: string[] | null = null;
     if (Array.isArray(body?.permissions) && body.permissions.length > 0) {
       const userPerms = getPermissions(user.role);
-      const invalid = body.permissions.filter((p: string) => !userPerms.includes(p as any));
+      const permSet = new Set<string>(userPerms);
+      const invalid = body.permissions.filter((p: string) => !permSet.has(p));
       if (invalid.length > 0) {
         return reply.status(400).send({
           error: `Cannot scope key with permissions you don't have: ${invalid.join(", ")}`,

--- a/apps/api/src/routes/api-keys.ts
+++ b/apps/api/src/routes/api-keys.ts
@@ -6,7 +6,6 @@
  * DELETE /api/v1/api-keys/:id  — Delete an API key
  */
 import { randomBytes, randomUUID } from "node:crypto";
-import type { Role } from "@ashim/shared";
 import { and, eq } from "drizzle-orm";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { db, schema } from "../db/index.js";
@@ -32,7 +31,7 @@ export async function apiKeyRoutes(app: FastifyInstance): Promise<void> {
 
     let scopedPermissions: string[] | null = null;
     if (Array.isArray(body?.permissions) && body.permissions.length > 0) {
-      const userPerms = getPermissions(user.role as Role);
+      const userPerms = getPermissions(user.role);
       const invalid = body.permissions.filter((p: string) => !userPerms.includes(p as any));
       if (invalid.length > 0) {
         return reply.status(400).send({

--- a/apps/api/src/routes/api-keys.ts
+++ b/apps/api/src/routes/api-keys.ts
@@ -19,7 +19,11 @@ export async function apiKeyRoutes(app: FastifyInstance): Promise<void> {
     const user = requireAuth(request, reply);
     if (!user) return;
 
-    const body = request.body as { name?: string; permissions?: string[] } | null;
+    const body = request.body as {
+      name?: string;
+      permissions?: string[];
+      expiresAt?: string;
+    } | null;
     const name = body?.name?.trim() || "Default API Key";
 
     if (name.length > 100) {
@@ -42,6 +46,22 @@ export async function apiKeyRoutes(app: FastifyInstance): Promise<void> {
       scopedPermissions = body.permissions;
     }
 
+    let expiresAt: Date | null = null;
+    if (body?.expiresAt) {
+      const parsed = new Date(body.expiresAt);
+      if (Number.isNaN(parsed.getTime())) {
+        return reply
+          .status(400)
+          .send({ error: "Invalid expiresAt date", code: "VALIDATION_ERROR" });
+      }
+      if (parsed <= new Date()) {
+        return reply
+          .status(400)
+          .send({ error: "expiresAt must be in the future", code: "VALIDATION_ERROR" });
+      }
+      expiresAt = parsed;
+    }
+
     // Generate a raw API key: "si_" prefix + 48 random bytes as hex
     const rawKey = `si_${randomBytes(48).toString("hex")}`;
     const keyHash = await hashPassword(rawKey);
@@ -56,6 +76,7 @@ export async function apiKeyRoutes(app: FastifyInstance): Promise<void> {
         keyPrefix,
         name,
         permissions: scopedPermissions ? JSON.stringify(scopedPermissions) : null,
+        expiresAt,
       })
       .run();
 
@@ -67,6 +88,7 @@ export async function apiKeyRoutes(app: FastifyInstance): Promise<void> {
       key: rawKey,
       name,
       permissions: scopedPermissions,
+      expiresAt: expiresAt?.toISOString() ?? null,
       createdAt: new Date().toISOString(),
     });
   });
@@ -82,6 +104,7 @@ export async function apiKeyRoutes(app: FastifyInstance): Promise<void> {
       permissions: schema.apiKeys.permissions,
       createdAt: schema.apiKeys.createdAt,
       lastUsedAt: schema.apiKeys.lastUsedAt,
+      expiresAt: schema.apiKeys.expiresAt,
     };
     const keys = hasEffectivePermission(user, "apikeys:all")
       ? db.select(selectFields).from(schema.apiKeys).all()
@@ -98,6 +121,7 @@ export async function apiKeyRoutes(app: FastifyInstance): Promise<void> {
         permissions: k.permissions ? JSON.parse(k.permissions) : null,
         createdAt: k.createdAt.toISOString(),
         lastUsedAt: k.lastUsedAt?.toISOString() ?? null,
+        expiresAt: k.expiresAt?.toISOString() ?? null,
       })),
     });
   });

--- a/apps/api/src/routes/api-keys.ts
+++ b/apps/api/src/routes/api-keys.ts
@@ -11,7 +11,7 @@ import { and, eq } from "drizzle-orm";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { db, schema } from "../db/index.js";
 import { auditLog } from "../lib/audit.js";
-import { hasPermission } from "../permissions.js";
+import { getPermissions, hasEffectivePermission } from "../permissions.js";
 import { computeKeyPrefix, hashPassword, requireAuth } from "../plugins/auth.js";
 
 export async function apiKeyRoutes(app: FastifyInstance): Promise<void> {
@@ -20,7 +20,7 @@ export async function apiKeyRoutes(app: FastifyInstance): Promise<void> {
     const user = requireAuth(request, reply);
     if (!user) return;
 
-    const body = request.body as { name?: string } | null;
+    const body = request.body as { name?: string; permissions?: string[] } | null;
     const name = body?.name?.trim() || "Default API Key";
 
     if (name.length > 100) {
@@ -28,6 +28,19 @@ export async function apiKeyRoutes(app: FastifyInstance): Promise<void> {
         error: "Key name must be 100 characters or fewer",
         code: "VALIDATION_ERROR",
       });
+    }
+
+    let scopedPermissions: string[] | null = null;
+    if (Array.isArray(body?.permissions) && body.permissions.length > 0) {
+      const userPerms = getPermissions(user.role as Role);
+      const invalid = body.permissions.filter((p: string) => !userPerms.includes(p as any));
+      if (invalid.length > 0) {
+        return reply.status(400).send({
+          error: `Cannot scope key with permissions you don't have: ${invalid.join(", ")}`,
+          code: "VALIDATION_ERROR",
+        });
+      }
+      scopedPermissions = body.permissions;
     }
 
     // Generate a raw API key: "si_" prefix + 48 random bytes as hex
@@ -43,6 +56,7 @@ export async function apiKeyRoutes(app: FastifyInstance): Promise<void> {
         keyHash,
         keyPrefix,
         name,
+        permissions: scopedPermissions ? JSON.stringify(scopedPermissions) : null,
       })
       .run();
 
@@ -53,6 +67,7 @@ export async function apiKeyRoutes(app: FastifyInstance): Promise<void> {
       id,
       key: rawKey,
       name,
+      permissions: scopedPermissions,
       createdAt: new Date().toISOString(),
     });
   });
@@ -65,10 +80,11 @@ export async function apiKeyRoutes(app: FastifyInstance): Promise<void> {
     const selectFields = {
       id: schema.apiKeys.id,
       name: schema.apiKeys.name,
+      permissions: schema.apiKeys.permissions,
       createdAt: schema.apiKeys.createdAt,
       lastUsedAt: schema.apiKeys.lastUsedAt,
     };
-    const keys = hasPermission(user.role as Role, "apikeys:all")
+    const keys = hasEffectivePermission(user, "apikeys:all")
       ? db.select(selectFields).from(schema.apiKeys).all()
       : db
           .select(selectFields)
@@ -80,6 +96,7 @@ export async function apiKeyRoutes(app: FastifyInstance): Promise<void> {
       apiKeys: keys.map((k) => ({
         id: k.id,
         name: k.name,
+        permissions: k.permissions ? JSON.parse(k.permissions) : null,
         createdAt: k.createdAt.toISOString(),
         lastUsedAt: k.lastUsedAt?.toISOString() ?? null,
       })),

--- a/apps/api/src/routes/api-keys.ts
+++ b/apps/api/src/routes/api-keys.ts
@@ -6,10 +6,12 @@
  * DELETE /api/v1/api-keys/:id  — Delete an API key
  */
 import { randomBytes, randomUUID } from "node:crypto";
+import type { Role } from "@ashim/shared";
 import { and, eq } from "drizzle-orm";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { db, schema } from "../db/index.js";
 import { auditLog } from "../lib/audit.js";
+import { hasPermission } from "../permissions.js";
 import { computeKeyPrefix, hashPassword, requireAuth } from "../plugins/auth.js";
 
 export async function apiKeyRoutes(app: FastifyInstance): Promise<void> {
@@ -66,14 +68,13 @@ export async function apiKeyRoutes(app: FastifyInstance): Promise<void> {
       createdAt: schema.apiKeys.createdAt,
       lastUsedAt: schema.apiKeys.lastUsedAt,
     };
-    const keys =
-      user.role === "admin"
-        ? db.select(selectFields).from(schema.apiKeys).all()
-        : db
-            .select(selectFields)
-            .from(schema.apiKeys)
-            .where(eq(schema.apiKeys.userId, user.id))
-            .all();
+    const keys = hasPermission(user.role as Role, "apikeys:all")
+      ? db.select(selectFields).from(schema.apiKeys).all()
+      : db
+          .select(selectFields)
+          .from(schema.apiKeys)
+          .where(eq(schema.apiKeys.userId, user.id))
+          .all();
 
     return reply.send({
       apiKeys: keys.map((k) => ({

--- a/apps/api/src/routes/audit-log.ts
+++ b/apps/api/src/routes/audit-log.ts
@@ -1,0 +1,83 @@
+import { and, desc, eq, gte, lte, sql } from "drizzle-orm";
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { db, schema } from "../db/index.js";
+import { requirePermission } from "../permissions.js";
+
+export async function auditLogRoutes(app: FastifyInstance): Promise<void> {
+  app.get(
+    "/api/v1/audit-log",
+    async (
+      request: FastifyRequest<{
+        Querystring: {
+          page?: string;
+          limit?: string;
+          action?: string;
+          from?: string;
+          to?: string;
+        };
+      }>,
+      reply: FastifyReply,
+    ) => {
+      const user = requirePermission("audit:read")(request, reply);
+      if (!user) return;
+
+      const page = Math.max(1, parseInt(request.query.page ?? "1", 10) || 1);
+      const limit = Math.min(100, Math.max(1, parseInt(request.query.limit ?? "50", 10) || 50));
+      const offset = (page - 1) * limit;
+
+      const conditions = [];
+
+      if (request.query.action) {
+        conditions.push(eq(schema.auditLog.action, request.query.action));
+      }
+      if (request.query.from) {
+        const fromDate = new Date(request.query.from);
+        if (!Number.isNaN(fromDate.getTime())) {
+          conditions.push(gte(schema.auditLog.createdAt, fromDate));
+        }
+      }
+      if (request.query.to) {
+        const toDate = new Date(request.query.to);
+        if (!Number.isNaN(toDate.getTime())) {
+          conditions.push(lte(schema.auditLog.createdAt, toDate));
+        }
+      }
+
+      const where = conditions.length > 0 ? and(...conditions) : undefined;
+
+      const entries = db
+        .select()
+        .from(schema.auditLog)
+        .where(where)
+        .orderBy(desc(schema.auditLog.createdAt))
+        .limit(limit)
+        .offset(offset)
+        .all();
+
+      const countResult = db
+        .select({ count: sql<number>`count(*)` })
+        .from(schema.auditLog)
+        .where(where)
+        .get();
+
+      return reply.send({
+        entries: entries.map((e) => ({
+          id: e.id,
+          actorId: e.actorId,
+          actorUsername: e.actorUsername,
+          action: e.action,
+          targetType: e.targetType,
+          targetId: e.targetId,
+          details: e.details ? JSON.parse(e.details) : null,
+          ipAddress: e.ipAddress,
+          createdAt: e.createdAt.toISOString(),
+        })),
+        total: countResult?.count ?? 0,
+        page,
+        limit,
+      });
+    },
+  );
+
+  app.log.info("Audit log routes registered");
+}

--- a/apps/api/src/routes/branding.ts
+++ b/apps/api/src/routes/branding.ts
@@ -14,7 +14,7 @@ import sharp from "sharp";
 import { env } from "../config.js";
 import { db, schema } from "../db/index.js";
 import { ensureSharpCompat } from "../lib/heic-converter.js";
-import { requireAdmin } from "../plugins/auth.js";
+import { requirePermission } from "../permissions.js";
 
 const BRANDING_DIR = join(process.cwd(), "data", "branding");
 const LOGO_PATH = join(BRANDING_DIR, "logo.png");
@@ -35,7 +35,7 @@ function upsertSetting(key: string, value: string): void {
 export async function brandingRoutes(app: FastifyInstance): Promise<void> {
   // POST /api/v1/settings/logo — Upload logo (admin only)
   app.post("/api/v1/settings/logo", async (request: FastifyRequest, reply: FastifyReply) => {
-    const admin = requireAdmin(request, reply);
+    const admin = requirePermission("branding:manage")(request, reply);
     if (!admin) return;
 
     const file = await request.file();
@@ -90,7 +90,7 @@ export async function brandingRoutes(app: FastifyInstance): Promise<void> {
 
   // DELETE /api/v1/settings/logo — Remove logo (admin only)
   app.delete("/api/v1/settings/logo", async (request: FastifyRequest, reply: FastifyReply) => {
-    const admin = requireAdmin(request, reply);
+    const admin = requirePermission("branding:manage")(request, reply);
     if (!admin) return;
 
     if (existsSync(LOGO_PATH)) {

--- a/apps/api/src/routes/features.ts
+++ b/apps/api/src/routes/features.ts
@@ -27,7 +27,8 @@ import {
   releaseInstallLock,
   setInstallProgress,
 } from "../lib/feature-status.js";
-import { requireAdmin, requireAuth } from "../plugins/auth.js";
+import { requirePermission } from "../permissions.js";
+import { requireAuth } from "../plugins/auth.js";
 import { updateSingleFileProgress } from "./progress.js";
 
 const venvPath = process.env.PYTHON_VENV_PATH || "/opt/venv";
@@ -110,7 +111,7 @@ export async function registerFeatureRoutes(app: FastifyInstance): Promise<void>
   app.post(
     "/api/v1/admin/features/:bundleId/install",
     async (request: FastifyRequest<{ Params: BundleIdParams }>, reply: FastifyReply) => {
-      const admin = requireAdmin(request, reply);
+      const admin = requirePermission("features:manage")(request, reply);
       if (!admin) return;
 
       const { bundleId } = request.params;
@@ -215,7 +216,7 @@ export async function registerFeatureRoutes(app: FastifyInstance): Promise<void>
   app.post(
     "/api/v1/admin/features/:bundleId/uninstall",
     async (request: FastifyRequest<{ Params: BundleIdParams }>, reply: FastifyReply) => {
-      const admin = requireAdmin(request, reply);
+      const admin = requirePermission("features:manage")(request, reply);
       if (!admin) return;
 
       const { bundleId } = request.params;
@@ -271,7 +272,7 @@ export async function registerFeatureRoutes(app: FastifyInstance): Promise<void>
   app.get(
     "/api/v1/admin/features/disk-usage",
     async (request: FastifyRequest, reply: FastifyReply) => {
-      const admin = requireAdmin(request, reply);
+      const admin = requirePermission("features:manage")(request, reply);
       if (!admin) return;
 
       const totalBytes = getDirSize(getAiDir());

--- a/apps/api/src/routes/pipeline.ts
+++ b/apps/api/src/routes/pipeline.ts
@@ -9,6 +9,7 @@
 import { randomUUID } from "node:crypto";
 import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import type { Role } from "@ashim/shared";
 import { getBundleForTool, TOOL_BUNDLE_MAP } from "@ashim/shared";
 import archiver from "archiver";
 import { eq } from "drizzle-orm";
@@ -26,6 +27,7 @@ import { sanitizeFilename } from "../lib/filename.js";
 import { decodeToSharpCompat, needsCliDecode } from "../lib/format-decoders.js";
 import { decodeHeic } from "../lib/heic-converter.js";
 import { createWorkspace } from "../lib/workspace.js";
+import { hasPermission } from "../permissions.js";
 import { requireAuth } from "../plugins/auth.js";
 import { type JobProgress, updateJobProgress } from "./progress.js";
 import { getRegisteredToolIds, getToolConfig } from "./tool-factory.js";
@@ -335,10 +337,9 @@ export async function registerPipelineRoutes(app: FastifyInstance): Promise<void
 
     // Admins see all pipelines; regular users see their own + legacy (no owner)
     const allRows = db.select().from(schema.pipelines).all();
-    const rows =
-      user.role === "admin"
-        ? allRows
-        : allRows.filter((row) => !row.userId || row.userId === user.id);
+    const rows = hasPermission(user.role as Role, "pipelines:all")
+      ? allRows
+      : allRows.filter((row) => !row.userId || row.userId === user.id);
 
     const pipelines = rows.map((row) => ({
       id: row.id,
@@ -371,7 +372,11 @@ export async function registerPipelineRoutes(app: FastifyInstance): Promise<void
       }
 
       // Only the owner (or admin) can delete; legacy pipelines (no owner) can be deleted by anyone
-      if (existing.userId && existing.userId !== user.id && user.role !== "admin") {
+      if (
+        existing.userId &&
+        existing.userId !== user.id &&
+        !hasPermission(user.role as Role, "pipelines:all")
+      ) {
         return reply.status(403).send({ error: "Not authorized to delete this pipeline" });
       }
 

--- a/apps/api/src/routes/pipeline.ts
+++ b/apps/api/src/routes/pipeline.ts
@@ -9,7 +9,6 @@
 import { randomUUID } from "node:crypto";
 import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import type { Role } from "@ashim/shared";
 import { getBundleForTool, TOOL_BUNDLE_MAP } from "@ashim/shared";
 import archiver from "archiver";
 import { eq } from "drizzle-orm";
@@ -27,7 +26,7 @@ import { sanitizeFilename } from "../lib/filename.js";
 import { decodeToSharpCompat, needsCliDecode } from "../lib/format-decoders.js";
 import { decodeHeic } from "../lib/heic-converter.js";
 import { createWorkspace } from "../lib/workspace.js";
-import { hasPermission } from "../permissions.js";
+import { hasEffectivePermission } from "../permissions.js";
 import { requireAuth } from "../plugins/auth.js";
 import { type JobProgress, updateJobProgress } from "./progress.js";
 import { getRegisteredToolIds, getToolConfig } from "./tool-factory.js";
@@ -337,7 +336,7 @@ export async function registerPipelineRoutes(app: FastifyInstance): Promise<void
 
     // Admins see all pipelines; regular users see their own + legacy (no owner)
     const allRows = db.select().from(schema.pipelines).all();
-    const rows = hasPermission(user.role as Role, "pipelines:all")
+    const rows = hasEffectivePermission(user, "pipelines:all")
       ? allRows
       : allRows.filter((row) => !row.userId || row.userId === user.id);
 
@@ -375,7 +374,7 @@ export async function registerPipelineRoutes(app: FastifyInstance): Promise<void
       if (
         existing.userId &&
         existing.userId !== user.id &&
-        !hasPermission(user.role as Role, "pipelines:all")
+        !hasEffectivePermission(user, "pipelines:all")
       ) {
         return reply.status(403).send({ error: "Not authorized to delete this pipeline" });
       }

--- a/apps/api/src/routes/roles.ts
+++ b/apps/api/src/routes/roles.ts
@@ -1,0 +1,218 @@
+import { randomUUID } from "node:crypto";
+import type { Permission } from "@ashim/shared";
+import { eq, sql } from "drizzle-orm";
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { db, schema } from "../db/index.js";
+import { auditLog } from "../lib/audit.js";
+import { requirePermission } from "../permissions.js";
+
+const ALL_PERMISSIONS: Permission[] = [
+  "tools:use",
+  "files:own",
+  "files:all",
+  "apikeys:own",
+  "apikeys:all",
+  "pipelines:own",
+  "pipelines:all",
+  "settings:read",
+  "settings:write",
+  "users:manage",
+  "teams:manage",
+  "branding:manage",
+  "features:manage",
+  "system:health",
+  "audit:read",
+];
+
+export async function rolesRoutes(app: FastifyInstance): Promise<void> {
+  // GET /api/v1/roles — List all roles (requires audit:read to view)
+  app.get("/api/v1/roles", async (request: FastifyRequest, reply: FastifyReply) => {
+    const user = requirePermission("audit:read")(request, reply);
+    if (!user) return;
+
+    const roles = db.select().from(schema.roles).all();
+    const userCounts = db
+      .select({
+        role: schema.users.role,
+        count: sql<number>`COUNT(*)`,
+      })
+      .from(schema.users)
+      .groupBy(schema.users.role)
+      .all();
+    const countMap = new Map(userCounts.map((r) => [r.role, r.count]));
+
+    return reply.send({
+      roles: roles.map((r) => ({
+        id: r.id,
+        name: r.name,
+        description: r.description,
+        permissions: JSON.parse(r.permissions),
+        isBuiltin: r.isBuiltin,
+        userCount: countMap.get(r.name) ?? 0,
+        createdAt: r.createdAt.toISOString(),
+        updatedAt: r.updatedAt.toISOString(),
+      })),
+    });
+  });
+
+  // POST /api/v1/roles — Create custom role
+  app.post("/api/v1/roles", async (request: FastifyRequest, reply: FastifyReply) => {
+    const user = requirePermission("users:manage")(request, reply);
+    if (!user) return;
+
+    const body = request.body as {
+      name?: string;
+      description?: string;
+      permissions?: string[];
+    } | null;
+    if (!body?.name || !Array.isArray(body?.permissions)) {
+      return reply
+        .status(400)
+        .send({ error: "Name and permissions are required", code: "VALIDATION_ERROR" });
+    }
+
+    const name = body.name.trim().toLowerCase();
+    if (name.length < 2 || name.length > 30) {
+      return reply
+        .status(400)
+        .send({ error: "Role name must be 2-30 characters", code: "VALIDATION_ERROR" });
+    }
+    if (!/^[a-z0-9_-]+$/.test(name)) {
+      return reply.status(400).send({
+        error: "Role name can only contain lowercase letters, numbers, hyphens, and underscores",
+        code: "VALIDATION_ERROR",
+      });
+    }
+
+    const invalid = body.permissions.filter((p) => !ALL_PERMISSIONS.includes(p as Permission));
+    if (invalid.length > 0) {
+      return reply
+        .status(400)
+        .send({ error: `Invalid permissions: ${invalid.join(", ")}`, code: "VALIDATION_ERROR" });
+    }
+
+    const existing = db.select().from(schema.roles).where(eq(schema.roles.name, name)).get();
+    if (existing) {
+      return reply.status(409).send({ error: "Role name already exists", code: "CONFLICT" });
+    }
+
+    const id = randomUUID();
+    db.insert(schema.roles)
+      .values({
+        id,
+        name,
+        description: body.description?.trim() ?? "",
+        permissions: JSON.stringify(body.permissions),
+        isBuiltin: false,
+        createdBy: user.id,
+      })
+      .run();
+
+    auditLog(request.log, "ROLE_CREATED", { adminId: user.id, roleId: id, roleName: name });
+
+    return reply.status(201).send({
+      id,
+      name,
+      description: body.description?.trim() ?? "",
+      permissions: body.permissions,
+      isBuiltin: false,
+    });
+  });
+
+  // PUT /api/v1/roles/:id — Update custom role
+  app.put(
+    "/api/v1/roles/:id",
+    async (request: FastifyRequest<{ Params: { id: string } }>, reply: FastifyReply) => {
+      const user = requirePermission("users:manage")(request, reply);
+      if (!user) return;
+
+      const { id } = request.params;
+      const role = db.select().from(schema.roles).where(eq(schema.roles.id, id)).get();
+      if (!role) {
+        return reply.status(404).send({ error: "Role not found", code: "NOT_FOUND" });
+      }
+      if (role.isBuiltin) {
+        return reply
+          .status(400)
+          .send({ error: "Cannot modify built-in roles", code: "VALIDATION_ERROR" });
+      }
+
+      const body = request.body as {
+        name?: string;
+        description?: string;
+        permissions?: string[];
+      } | null;
+      const updates: Record<string, unknown> = { updatedAt: new Date() };
+
+      if (body?.name) {
+        const name = body.name.trim().toLowerCase();
+        if (name.length < 2 || name.length > 30) {
+          return reply
+            .status(400)
+            .send({ error: "Role name must be 2-30 characters", code: "VALIDATION_ERROR" });
+        }
+        const dup = db.select().from(schema.roles).where(eq(schema.roles.name, name)).get();
+        if (dup && dup.id !== id) {
+          return reply.status(409).send({ error: "Role name already exists", code: "CONFLICT" });
+        }
+        // Update users on old role name to new name
+        db.update(schema.users).set({ role: name }).where(eq(schema.users.role, role.name)).run();
+        updates.name = name;
+      }
+      if (body?.description !== undefined) {
+        updates.description = body.description.trim();
+      }
+      if (Array.isArray(body?.permissions)) {
+        const invalid = body.permissions.filter((p) => !ALL_PERMISSIONS.includes(p as Permission));
+        if (invalid.length > 0) {
+          return reply.status(400).send({
+            error: `Invalid permissions: ${invalid.join(", ")}`,
+            code: "VALIDATION_ERROR",
+          });
+        }
+        updates.permissions = JSON.stringify(body.permissions);
+      }
+
+      db.update(schema.roles).set(updates).where(eq(schema.roles.id, id)).run();
+      auditLog(request.log, "ROLE_UPDATED", { adminId: user.id, roleId: id });
+
+      return reply.send({ ok: true });
+    },
+  );
+
+  // DELETE /api/v1/roles/:id — Delete custom role
+  app.delete(
+    "/api/v1/roles/:id",
+    async (request: FastifyRequest<{ Params: { id: string } }>, reply: FastifyReply) => {
+      const user = requirePermission("users:manage")(request, reply);
+      if (!user) return;
+
+      const { id } = request.params;
+      const role = db.select().from(schema.roles).where(eq(schema.roles.id, id)).get();
+      if (!role) {
+        return reply.status(404).send({ error: "Role not found", code: "NOT_FOUND" });
+      }
+      if (role.isBuiltin) {
+        return reply
+          .status(400)
+          .send({ error: "Cannot delete built-in roles", code: "VALIDATION_ERROR" });
+      }
+
+      db.update(schema.users)
+        .set({ role: "user", updatedAt: new Date() })
+        .where(eq(schema.users.role, role.name))
+        .run();
+
+      db.delete(schema.roles).where(eq(schema.roles.id, id)).run();
+      auditLog(request.log, "ROLE_DELETED", {
+        adminId: user.id,
+        roleId: id,
+        roleName: role.name,
+      });
+
+      return reply.send({ ok: true });
+    },
+  );
+
+  app.log.info("Roles routes registered");
+}

--- a/apps/api/src/routes/settings.ts
+++ b/apps/api/src/routes/settings.ts
@@ -9,7 +9,8 @@
 import { eq } from "drizzle-orm";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { db, schema } from "../db/index.js";
-import { requireAdmin, requireAuth } from "../plugins/auth.js";
+import { requirePermission } from "../permissions.js";
+import { requireAuth } from "../plugins/auth.js";
 
 const HTML_TAG_PATTERN = /<[a-z/!][^>]*>/i;
 
@@ -31,7 +32,7 @@ export async function settingsRoutes(app: FastifyInstance): Promise<void> {
 
   // PUT /api/v1/settings — Save settings (admin only)
   app.put("/api/v1/settings", async (request: FastifyRequest, reply: FastifyReply) => {
-    const admin = requireAdmin(request, reply);
+    const admin = requirePermission("settings:write")(request, reply);
     if (!admin) return;
 
     const body = request.body as Record<string, unknown> | null;

--- a/apps/api/src/routes/teams.ts
+++ b/apps/api/src/routes/teams.ts
@@ -11,7 +11,7 @@ import { randomUUID } from "node:crypto";
 import { eq, sql } from "drizzle-orm";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { db, schema } from "../db/index.js";
-import { requireAdmin } from "../plugins/auth.js";
+import { requirePermission } from "../permissions.js";
 
 function validateTeamName(name: unknown): string | null {
   if (typeof name !== "string") return "Team name is required";
@@ -24,7 +24,7 @@ function validateTeamName(name: unknown): string | null {
 export async function teamsRoutes(app: FastifyInstance): Promise<void> {
   // GET /api/v1/teams — List all teams with member count (admin only)
   app.get("/api/v1/teams", async (request: FastifyRequest, reply: FastifyReply) => {
-    const user = requireAdmin(request, reply);
+    const user = requirePermission("teams:manage")(request, reply);
     if (!user) return;
 
     const teams = db
@@ -47,7 +47,7 @@ export async function teamsRoutes(app: FastifyInstance): Promise<void> {
 
   // POST /api/v1/teams — Create team (admin only)
   app.post("/api/v1/teams", async (request: FastifyRequest, reply: FastifyReply) => {
-    const admin = requireAdmin(request, reply);
+    const admin = requirePermission("teams:manage")(request, reply);
     if (!admin) return;
 
     const body = request.body as { name?: string } | null;
@@ -81,7 +81,7 @@ export async function teamsRoutes(app: FastifyInstance): Promise<void> {
   app.put(
     "/api/v1/teams/:id",
     async (request: FastifyRequest<{ Params: { id: string } }>, reply: FastifyReply) => {
-      const admin = requireAdmin(request, reply);
+      const admin = requirePermission("teams:manage")(request, reply);
       if (!admin) return;
 
       const { id } = request.params;
@@ -122,7 +122,7 @@ export async function teamsRoutes(app: FastifyInstance): Promise<void> {
   app.delete(
     "/api/v1/teams/:id",
     async (request: FastifyRequest<{ Params: { id: string } }>, reply: FastifyReply) => {
-      const admin = requireAdmin(request, reply);
+      const admin = requirePermission("teams:manage")(request, reply);
       if (!admin) return;
 
       const { id } = request.params;

--- a/apps/api/src/routes/user-files.ts
+++ b/apps/api/src/routes/user-files.ts
@@ -13,6 +13,7 @@ import { randomUUID } from "node:crypto";
 import { createReadStream } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { extname } from "node:path";
+import type { Role } from "@ashim/shared";
 import { and, desc, eq, like, sql } from "drizzle-orm";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import sharp from "sharp";
@@ -29,6 +30,7 @@ import {
 import { validateImageBuffer } from "../lib/file-validation.js";
 import { sanitizeFilename } from "../lib/filename.js";
 import { ensureSharpCompat } from "../lib/heic-converter.js";
+import { hasPermission } from "../permissions.js";
 import { getAuthUser, requireAuth } from "../plugins/auth.js";
 
 // ── Helpers ────────────────────────────────────────────────────────
@@ -115,8 +117,8 @@ export async function userFileRoutes(app: FastifyInstance): Promise<void> {
       // Build the where clauses
       const conditions = [latestCondition];
 
-      // Non-admin users only see their own files; admins see all
-      if (user.role !== "admin") {
+      // Users without files:all only see their own files
+      if (!hasPermission(user.role as Role, "files:all")) {
         conditions.push(eq(schema.userFiles.userId, user.id));
       }
 
@@ -241,7 +243,7 @@ export async function userFileRoutes(app: FastifyInstance): Promise<void> {
 
       const file = db.select().from(schema.userFiles).where(eq(schema.userFiles.id, id)).get();
 
-      if (!file || (user.role !== "admin" && file.userId !== user.id)) {
+      if (!file || (file.userId !== user.id && !hasPermission(user.role as Role, "files:all"))) {
         return reply.status(404).send({ error: "File not found" });
       }
 
@@ -321,7 +323,7 @@ export async function userFileRoutes(app: FastifyInstance): Promise<void> {
 
       const file = db.select().from(schema.userFiles).where(eq(schema.userFiles.id, id)).get();
 
-      if (!file || (user.role !== "admin" && file.userId !== user.id)) {
+      if (!file || (file.userId !== user.id && !hasPermission(user.role as Role, "files:all"))) {
         return reply.status(404).send({ error: "File not found" });
       }
 
@@ -422,7 +424,8 @@ export async function userFileRoutes(app: FastifyInstance): Promise<void> {
     for (const id of ids) {
       // Ownership check: non-admin users can only delete their own files
       const file = db.select().from(schema.userFiles).where(eq(schema.userFiles.id, id)).get();
-      if (!file || (user.role !== "admin" && file.userId !== user.id)) continue;
+      if (!file || (file.userId !== user.id && !hasPermission(user.role as Role, "files:all")))
+        continue;
       // Collect all files in the chain using a recursive CTE
       const chainRows = sqlite
         .prepare(`

--- a/apps/api/src/routes/user-files.ts
+++ b/apps/api/src/routes/user-files.ts
@@ -13,7 +13,6 @@ import { randomUUID } from "node:crypto";
 import { createReadStream } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { extname } from "node:path";
-import type { Role } from "@ashim/shared";
 import { and, desc, eq, like, sql } from "drizzle-orm";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import sharp from "sharp";
@@ -30,7 +29,7 @@ import {
 import { validateImageBuffer } from "../lib/file-validation.js";
 import { sanitizeFilename } from "../lib/filename.js";
 import { ensureSharpCompat } from "../lib/heic-converter.js";
-import { hasPermission } from "../permissions.js";
+import { hasEffectivePermission } from "../permissions.js";
 import { getAuthUser, requireAuth } from "../plugins/auth.js";
 
 // ── Helpers ────────────────────────────────────────────────────────
@@ -118,7 +117,7 @@ export async function userFileRoutes(app: FastifyInstance): Promise<void> {
       const conditions = [latestCondition];
 
       // Users without files:all only see their own files
-      if (!hasPermission(user.role as Role, "files:all")) {
+      if (!hasEffectivePermission(user, "files:all")) {
         conditions.push(eq(schema.userFiles.userId, user.id));
       }
 
@@ -243,7 +242,7 @@ export async function userFileRoutes(app: FastifyInstance): Promise<void> {
 
       const file = db.select().from(schema.userFiles).where(eq(schema.userFiles.id, id)).get();
 
-      if (!file || (file.userId !== user.id && !hasPermission(user.role as Role, "files:all"))) {
+      if (!file || (file.userId !== user.id && !hasEffectivePermission(user, "files:all"))) {
         return reply.status(404).send({ error: "File not found" });
       }
 
@@ -323,7 +322,7 @@ export async function userFileRoutes(app: FastifyInstance): Promise<void> {
 
       const file = db.select().from(schema.userFiles).where(eq(schema.userFiles.id, id)).get();
 
-      if (!file || (file.userId !== user.id && !hasPermission(user.role as Role, "files:all"))) {
+      if (!file || (file.userId !== user.id && !hasEffectivePermission(user, "files:all"))) {
         return reply.status(404).send({ error: "File not found" });
       }
 
@@ -424,7 +423,7 @@ export async function userFileRoutes(app: FastifyInstance): Promise<void> {
     for (const id of ids) {
       // Ownership check: non-admin users can only delete their own files
       const file = db.select().from(schema.userFiles).where(eq(schema.userFiles.id, id)).get();
-      if (!file || (file.userId !== user.id && !hasPermission(user.role as Role, "files:all")))
+      if (!file || (file.userId !== user.id && !hasEffectivePermission(user, "files:all")))
         continue;
       // Collect all files in the chain using a recursive CTE
       const chainRows = sqlite

--- a/apps/web/src/components/settings/settings-dialog.tsx
+++ b/apps/web/src/components/settings/settings-dialog.tsx
@@ -4,6 +4,7 @@ import {
   Copy,
   Eye,
   EyeOff,
+  FileText,
   Info,
   Key,
   Loader2,
@@ -25,7 +26,7 @@ import {
   Wrench,
   X,
 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
 import { useAuth } from "@/hooks/use-auth";
 import { apiDelete, apiGet, apiPost, apiPut, clearToken, formatHeaders } from "@/lib/api";
 import { cn, copyToClipboard } from "@/lib/utils";
@@ -45,6 +46,7 @@ type Section =
   | "people"
   | "teams"
   | "roles"
+  | "audit-log"
   | "api-keys"
   | "ai-features"
   | "tools"
@@ -64,6 +66,7 @@ const NAV_ITEMS: NavItem[] = [
   { id: "people", label: "People", icon: Users, requiredPermission: "users:manage" },
   { id: "teams", label: "Teams", icon: UsersRound, requiredPermission: "teams:manage" },
   { id: "roles", label: "Roles", icon: Shield, requiredPermission: "users:manage" },
+  { id: "audit-log", label: "Audit Log", icon: FileText, requiredPermission: "audit:read" },
   { id: "api-keys", label: "API Keys", icon: Key },
   { id: "ai-features", label: "AI Features", icon: Sparkles, requiredPermission: "settings:write" },
   { id: "tools", label: "Tools", icon: Wrench },
@@ -140,6 +143,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
           {section === "people" && <PeopleSection />}
           {section === "teams" && <TeamsSection />}
           {section === "roles" && <RolesSection />}
+          {section === "audit-log" && <AuditLogSection />}
           {section === "api-keys" && <ApiKeysSection />}
           {section === "ai-features" && <AiFeaturesSection />}
           {section === "tools" && <ToolsSection />}
@@ -2084,6 +2088,187 @@ function RolesSection() {
           ))
         )}
       </div>
+    </div>
+  );
+}
+
+/* ────────────────────── Audit Log ────────────────────── */
+
+const AUDIT_ACTIONS = [
+  "LOGIN_SUCCESS",
+  "LOGIN_FAILED",
+  "USER_CREATED",
+  "USER_UPDATED",
+  "USER_DELETED",
+  "PASSWORD_CHANGED",
+  "PASSWORD_RESET",
+  "API_KEY_CREATED",
+  "API_KEY_DELETED",
+  "ROLE_CREATED",
+  "ROLE_UPDATED",
+  "ROLE_DELETED",
+  "SETTINGS_UPDATED",
+] as const;
+
+interface AuditEntry {
+  id: string;
+  actorUsername: string;
+  action: string;
+  targetType: string | null;
+  targetId: string | null;
+  details: Record<string, unknown> | null;
+  createdAt: string;
+}
+
+function formatRelativeTime(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  if (days < 7) return `${days}d ago`;
+  return new Date(iso).toLocaleDateString();
+}
+
+function AuditLogSection() {
+  const [entries, setEntries] = useState<AuditEntry[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(true);
+  const [actionFilter, setActionFilter] = useState("");
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const limit = 25;
+
+  const fetchEntries = useCallback(async () => {
+    setLoading(true);
+    try {
+      const params = new URLSearchParams({ page: String(page), limit: String(limit) });
+      if (actionFilter) params.set("action", actionFilter);
+      const data = await apiGet<{ entries: AuditEntry[]; total: number }>(
+        `/v1/audit-log?${params}`,
+      );
+      setEntries(data.entries);
+      setTotal(data.total);
+    } catch {
+      setEntries([]);
+      setTotal(0);
+    } finally {
+      setLoading(false);
+    }
+  }, [page, actionFilter]);
+
+  useEffect(() => {
+    fetchEntries();
+  }, [fetchEntries]);
+
+  const totalPages = Math.max(1, Math.ceil(total / limit));
+
+  const handleFilterChange = (value: string) => {
+    setActionFilter(value);
+    setPage(1);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-semibold text-foreground">Audit Log</h3>
+        <select
+          value={actionFilter}
+          onChange={(e) => handleFilterChange(e.target.value)}
+          className="text-sm border border-border rounded-lg px-2 py-1.5 bg-background text-foreground"
+        >
+          <option value="">All actions</option>
+          {AUDIT_ACTIONS.map((a) => (
+            <option key={a} value={a}>
+              {a.replaceAll("_", " ")}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {loading ? (
+        <div className="flex items-center justify-center py-12">
+          <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+        </div>
+      ) : entries.length === 0 ? (
+        <p className="text-sm text-muted-foreground text-center py-8">No audit log entries.</p>
+      ) : (
+        <div className="border border-border rounded-lg overflow-hidden">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border bg-muted/30">
+                <th className="text-left px-3 py-2 font-medium text-muted-foreground">Time</th>
+                <th className="text-left px-3 py-2 font-medium text-muted-foreground">User</th>
+                <th className="text-left px-3 py-2 font-medium text-muted-foreground">Action</th>
+                <th className="text-left px-3 py-2 font-medium text-muted-foreground">Target</th>
+              </tr>
+            </thead>
+            <tbody>
+              {entries.map((entry) => (
+                <Fragment key={entry.id}>
+                  <tr
+                    className="border-b border-border last:border-0 hover:bg-muted/20 cursor-pointer transition-colors"
+                    onClick={() => setExpandedId(expandedId === entry.id ? null : entry.id)}
+                  >
+                    <td className="px-3 py-2 text-muted-foreground whitespace-nowrap">
+                      {formatRelativeTime(entry.createdAt)}
+                    </td>
+                    <td className="px-3 py-2 text-foreground">{entry.actorUsername}</td>
+                    <td className="px-3 py-2">
+                      <span className="font-mono text-xs bg-muted px-1.5 py-0.5 rounded">
+                        {entry.action}
+                      </span>
+                    </td>
+                    <td className="px-3 py-2 text-muted-foreground">
+                      {entry.targetType
+                        ? `${entry.targetType}${entry.targetId ? ` #${entry.targetId}` : ""}`
+                        : "—"}
+                    </td>
+                  </tr>
+                  {expandedId === entry.id && entry.details && (
+                    <tr className="border-b border-border last:border-0">
+                      <td colSpan={4} className="px-3 py-2 bg-muted/10">
+                        <pre className="text-xs text-muted-foreground whitespace-pre-wrap font-mono overflow-x-auto">
+                          {JSON.stringify(entry.details, null, 2)}
+                        </pre>
+                      </td>
+                    </tr>
+                  )}
+                </Fragment>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between text-sm">
+          <span className="text-muted-foreground">
+            Page {page} of {totalPages} ({total} entries)
+          </span>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              disabled={page <= 1}
+              onClick={() => setPage((p) => p - 1)}
+              className="px-3 py-1 rounded-lg border border-border text-foreground hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              Previous
+            </button>
+            <button
+              type="button"
+              disabled={page >= totalPages}
+              onClick={() => setPage((p) => p + 1)}
+              className="px-3 py-1 rounded-lg border border-border text-foreground hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/settings/settings-dialog.tsx
+++ b/apps/web/src/components/settings/settings-dialog.tsx
@@ -7,10 +7,12 @@ import {
   Info,
   Key,
   Loader2,
+  Lock,
   LogOut,
   Monitor,
   MoreVertical,
   Pencil,
+  Plus,
   RotateCcw,
   Search,
   Settings,
@@ -42,6 +44,7 @@ type Section =
   | "security"
   | "people"
   | "teams"
+  | "roles"
   | "api-keys"
   | "ai-features"
   | "tools"
@@ -60,6 +63,7 @@ const NAV_ITEMS: NavItem[] = [
   { id: "security", label: "Security", icon: Shield },
   { id: "people", label: "People", icon: Users, requiredPermission: "users:manage" },
   { id: "teams", label: "Teams", icon: UsersRound, requiredPermission: "teams:manage" },
+  { id: "roles", label: "Roles", icon: Shield, requiredPermission: "users:manage" },
   { id: "api-keys", label: "API Keys", icon: Key },
   { id: "ai-features", label: "AI Features", icon: Sparkles, requiredPermission: "settings:write" },
   { id: "tools", label: "Tools", icon: Wrench },
@@ -135,6 +139,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
           {section === "security" && <SecuritySection />}
           {section === "people" && <PeopleSection />}
           {section === "teams" && <TeamsSection />}
+          {section === "roles" && <RolesSection />}
           {section === "api-keys" && <ApiKeysSection />}
           {section === "ai-features" && <AiFeaturesSection />}
           {section === "tools" && <ToolsSection />}
@@ -159,6 +164,16 @@ interface ApiKeyEntry {
   prefix: string;
   createdAt: string;
   permissions: string[] | null;
+  expiresAt: string | null;
+}
+
+interface RoleEntry {
+  id: string;
+  name: string;
+  description: string;
+  permissions: string[];
+  isBuiltin: boolean;
+  userCount: number;
 }
 
 interface UserEntry {
@@ -705,6 +720,7 @@ function PeopleSection() {
     null,
   );
   const [teams, setTeams] = useState<TeamEntry[]>([]);
+  const [availableRoles, setAvailableRoles] = useState<RoleEntry[]>([]);
 
   const loadTeams = useCallback(async () => {
     try {
@@ -730,6 +746,9 @@ function PeopleSection() {
   useEffect(() => {
     loadUsers();
     loadTeams();
+    apiGet<{ roles: RoleEntry[] }>("/v1/roles")
+      .then((data) => setAvailableRoles(data.roles))
+      .catch(() => setAvailableRoles([]));
   }, [loadUsers, loadTeams]);
 
   // Close dropdown when clicking outside
@@ -935,9 +954,20 @@ function PeopleSection() {
               onChange={(e) => setNewRole(e.target.value)}
               className="px-3 py-2 rounded-lg border border-border bg-background text-sm text-foreground"
             >
-              <option value="user">User — Basic tool access</option>
-              <option value="editor">Editor — All files &amp; pipelines</option>
-              <option value="admin">Admin — Full access</option>
+              {availableRoles.length > 0 ? (
+                availableRoles.map((r) => (
+                  <option key={r.name} value={r.name}>
+                    {r.name.charAt(0).toUpperCase() + r.name.slice(1)} —{" "}
+                    {r.description || "No description"}
+                  </option>
+                ))
+              ) : (
+                <>
+                  <option value="user">User — Basic tool access</option>
+                  <option value="editor">Editor — All files &amp; pipelines</option>
+                  <option value="admin">Admin — Full access</option>
+                </>
+              )}
             </select>
             <select
               value={newTeam}
@@ -986,9 +1016,20 @@ function PeopleSection() {
               onChange={(e) => setEditRole(e.target.value)}
               className="px-3 py-2 rounded-lg border border-border bg-background text-sm text-foreground"
             >
-              <option value="user">User — Basic tool access</option>
-              <option value="editor">Editor — All files &amp; pipelines</option>
-              <option value="admin">Admin — Full access</option>
+              {availableRoles.length > 0 ? (
+                availableRoles.map((r) => (
+                  <option key={r.name} value={r.name}>
+                    {r.name.charAt(0).toUpperCase() + r.name.slice(1)} —{" "}
+                    {r.description || "No description"}
+                  </option>
+                ))
+              ) : (
+                <>
+                  <option value="user">User — Basic tool access</option>
+                  <option value="editor">Editor — All files &amp; pipelines</option>
+                  <option value="admin">Admin — Full access</option>
+                </>
+              )}
             </select>
             <select
               value={editTeam}
@@ -1183,6 +1224,7 @@ function ApiKeysSection() {
   const [keyName, setKeyName] = useState("");
   const [showScoping, setShowScoping] = useState(false);
   const [scopedPerms, setScopedPerms] = useState<string[]>([]);
+  const [expiresAt, setExpiresAt] = useState("");
   const { permissions } = useAuth();
 
   const loadKeys = useCallback(async () => {
@@ -1208,18 +1250,22 @@ function ApiKeysSection() {
       if (showScoping && scopedPerms.length > 0) {
         payload.permissions = scopedPerms;
       }
+      if (expiresAt) {
+        payload.expiresAt = new Date(expiresAt).toISOString();
+      }
       const data = await apiPost<{ key: string }>("/v1/api-keys", payload);
       setNewKey(data.key);
       setKeyName("");
       setScopedPerms([]);
       setShowScoping(false);
+      setExpiresAt("");
       await loadKeys();
     } catch {
       // Silently fail
     } finally {
       setGenerating(false);
     }
-  }, [keyName, showScoping, scopedPerms, loadKeys]);
+  }, [keyName, showScoping, scopedPerms, expiresAt, loadKeys]);
 
   const copyKey = useCallback(async (key: string) => {
     const ok = await copyToClipboard(key);
@@ -1312,6 +1358,29 @@ function ApiKeysSection() {
         )}
       </div>
 
+      {/* Expiration date */}
+      <div className="flex items-center gap-2">
+        <label className="text-xs text-muted-foreground flex items-center gap-2">
+          Expires:
+          <input
+            type="datetime-local"
+            value={expiresAt}
+            onChange={(e) => setExpiresAt(e.target.value)}
+            className="px-2 py-1 rounded border border-border bg-background text-xs text-foreground"
+            min={new Date().toISOString().slice(0, 16)}
+          />
+        </label>
+        {expiresAt && (
+          <button
+            type="button"
+            onClick={() => setExpiresAt("")}
+            className="text-xs text-muted-foreground hover:text-foreground"
+          >
+            Clear
+          </button>
+        )}
+      </div>
+
       {/* Newly generated key display */}
       {newKey && (
         <div className="space-y-2">
@@ -1352,6 +1421,11 @@ function ApiKeysSection() {
                   <p className="text-xs text-muted-foreground font-mono mt-0.5">
                     Scoped: {k.permissions.join(", ")}
                   </p>
+                )}
+                {k.expiresAt && (
+                  <span className="text-xs text-amber-500">
+                    Expires {new Date(k.expiresAt).toLocaleDateString()}
+                  </span>
                 )}
               </div>
               <button
@@ -1640,6 +1714,371 @@ function TeamsSection() {
                     </button>
                   </div>
                 )}
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ────────────────────── Roles ────────────────────── */
+
+const PERMISSION_GROUPS = [
+  { label: "Tools", permissions: ["tools:use"] },
+  { label: "Files", permissions: ["files:own", "files:all"] },
+  { label: "API Keys", permissions: ["apikeys:own", "apikeys:all"] },
+  { label: "Pipelines", permissions: ["pipelines:own", "pipelines:all"] },
+  { label: "Settings", permissions: ["settings:read", "settings:write"] },
+  { label: "Users", permissions: ["users:manage"] },
+  { label: "Teams", permissions: ["teams:manage"] },
+  { label: "Branding", permissions: ["branding:manage"] },
+  {
+    label: "System",
+    permissions: ["features:manage", "system:health", "audit:read"],
+  },
+];
+
+function RolesSection() {
+  const [roles, setRoles] = useState<RoleEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [newName, setNewName] = useState("");
+  const [newDescription, setNewDescription] = useState("");
+  const [newPermissions, setNewPermissions] = useState<string[]>([]);
+  const [editingRole, setEditingRole] = useState<RoleEntry | null>(null);
+  const [editPermissions, setEditPermissions] = useState<string[]>([]);
+  const [editName, setEditName] = useState("");
+  const [editDescription, setEditDescription] = useState("");
+  const [actionMsg, setActionMsg] = useState<{ type: "success" | "error"; text: string } | null>(
+    null,
+  );
+
+  const loadRoles = useCallback(async () => {
+    try {
+      const data = await apiGet<{ roles: RoleEntry[] }>("/v1/roles");
+      setRoles(data.roles);
+    } catch {
+      setRoles([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadRoles();
+  }, [loadRoles]);
+
+  const handleCreate = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      if (!newName.trim()) return;
+      try {
+        await apiPost("/v1/roles", {
+          name: newName.trim().toLowerCase(),
+          description: newDescription.trim(),
+          permissions: newPermissions,
+        });
+        setNewName("");
+        setNewDescription("");
+        setNewPermissions([]);
+        setShowCreateForm(false);
+        setActionMsg({ type: "success", text: "Role created successfully" });
+        await loadRoles();
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : "Failed to create role";
+        setActionMsg({
+          type: "error",
+          text: msg.includes("409") ? "A role with that name already exists" : msg,
+        });
+      }
+      setTimeout(() => setActionMsg(null), 3000);
+    },
+    [newName, newDescription, newPermissions, loadRoles],
+  );
+
+  const handleUpdate = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      if (!editingRole) return;
+      try {
+        await apiPut(`/v1/roles/${editingRole.id}`, {
+          name: editName.trim().toLowerCase(),
+          description: editDescription.trim(),
+          permissions: editPermissions,
+        });
+        setEditingRole(null);
+        setActionMsg({ type: "success", text: "Role updated" });
+        await loadRoles();
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : "Failed to update role";
+        setActionMsg({ type: "error", text: msg });
+      }
+      setTimeout(() => setActionMsg(null), 3000);
+    },
+    [editingRole, editName, editDescription, editPermissions, loadRoles],
+  );
+
+  const handleDelete = useCallback(
+    async (role: RoleEntry) => {
+      const msg =
+        role.userCount > 0
+          ? `Delete role "${role.name}"? ${role.userCount} user${role.userCount !== 1 ? "s" : ""} will need to be reassigned.`
+          : `Delete role "${role.name}"?`;
+      if (!confirm(msg)) return;
+      try {
+        await apiDelete(`/v1/roles/${role.id}`);
+        setActionMsg({ type: "success", text: `Role "${role.name}" deleted` });
+        await loadRoles();
+      } catch (err) {
+        const errMsg = err instanceof Error ? err.message : "Failed to delete role";
+        setActionMsg({ type: "error", text: errMsg });
+      }
+      setTimeout(() => setActionMsg(null), 3000);
+    },
+    [loadRoles],
+  );
+
+  const togglePermission = (perm: string, list: string[], setter: (v: string[]) => void) => {
+    setter(list.includes(perm) ? list.filter((p) => p !== perm) : [...list, perm]);
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-5">
+      <div>
+        <h3 className="text-lg font-semibold text-foreground">Roles</h3>
+        <p className="text-sm text-muted-foreground mt-1">
+          Manage roles and their permissions. Built-in roles cannot be modified.
+        </p>
+      </div>
+
+      {actionMsg && (
+        <div
+          className={cn(
+            "text-sm px-3 py-2 rounded-lg",
+            actionMsg.type === "error"
+              ? "bg-destructive/10 text-destructive"
+              : "bg-green-500/10 text-green-600 dark:text-green-400",
+          )}
+        >
+          {actionMsg.text}
+        </div>
+      )}
+
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={() => setShowCreateForm(!showCreateForm)}
+          className="flex items-center gap-2 px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors"
+        >
+          <Plus className="h-4 w-4" />
+          Create Custom Role
+        </button>
+      </div>
+
+      {/* Create role form */}
+      {showCreateForm && (
+        <form
+          onSubmit={handleCreate}
+          className="p-4 rounded-lg border border-border bg-muted/20 space-y-3"
+        >
+          <h4 className="text-sm font-medium text-foreground">New Role</h4>
+          <div className="grid grid-cols-2 gap-3">
+            <input
+              type="text"
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              placeholder="Role name"
+              required
+              className="px-3 py-2 rounded-lg border border-border bg-background text-sm text-foreground"
+            />
+            <input
+              type="text"
+              value={newDescription}
+              onChange={(e) => setNewDescription(e.target.value)}
+              placeholder="Description (optional)"
+              className="px-3 py-2 rounded-lg border border-border bg-background text-sm text-foreground"
+            />
+          </div>
+          <div>
+            <p className="text-xs font-medium text-muted-foreground mb-2">Permissions</p>
+            <div className="grid grid-cols-2 gap-3">
+              {PERMISSION_GROUPS.map((group) => (
+                <div key={group.label} className="space-y-1">
+                  <p className="text-xs font-semibold text-foreground">{group.label}</p>
+                  {group.permissions.map((perm) => (
+                    <label key={perm} className="flex items-center gap-1.5 text-xs cursor-pointer">
+                      <input
+                        type="checkbox"
+                        checked={newPermissions.includes(perm)}
+                        onChange={() => togglePermission(perm, newPermissions, setNewPermissions)}
+                        className="rounded border-border"
+                      />
+                      <span className="font-mono">{perm}</span>
+                    </label>
+                  ))}
+                </div>
+              ))}
+            </div>
+          </div>
+          <div className="flex items-center gap-3">
+            <button
+              type="submit"
+              className="flex items-center gap-2 px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors"
+            >
+              Create
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setShowCreateForm(false);
+                setNewName("");
+                setNewDescription("");
+                setNewPermissions([]);
+              }}
+              className="px-4 py-2 rounded-lg border border-border text-sm text-muted-foreground hover:bg-muted transition-colors"
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      )}
+
+      {/* Edit role form */}
+      {editingRole && (
+        <form
+          onSubmit={handleUpdate}
+          className="p-4 rounded-lg border border-primary/30 bg-primary/5 space-y-3"
+        >
+          <h4 className="text-sm font-medium text-foreground">Edit Role: {editingRole.name}</h4>
+          <div className="grid grid-cols-2 gap-3">
+            <input
+              type="text"
+              value={editName}
+              onChange={(e) => setEditName(e.target.value)}
+              placeholder="Role name"
+              required
+              className="px-3 py-2 rounded-lg border border-border bg-background text-sm text-foreground"
+            />
+            <input
+              type="text"
+              value={editDescription}
+              onChange={(e) => setEditDescription(e.target.value)}
+              placeholder="Description (optional)"
+              className="px-3 py-2 rounded-lg border border-border bg-background text-sm text-foreground"
+            />
+          </div>
+          <div>
+            <p className="text-xs font-medium text-muted-foreground mb-2">Permissions</p>
+            <div className="grid grid-cols-2 gap-3">
+              {PERMISSION_GROUPS.map((group) => (
+                <div key={group.label} className="space-y-1">
+                  <p className="text-xs font-semibold text-foreground">{group.label}</p>
+                  {group.permissions.map((perm) => (
+                    <label key={perm} className="flex items-center gap-1.5 text-xs cursor-pointer">
+                      <input
+                        type="checkbox"
+                        checked={editPermissions.includes(perm)}
+                        onChange={() => togglePermission(perm, editPermissions, setEditPermissions)}
+                        className="rounded border-border"
+                      />
+                      <span className="font-mono">{perm}</span>
+                    </label>
+                  ))}
+                </div>
+              ))}
+            </div>
+          </div>
+          <div className="flex items-center gap-3">
+            <button
+              type="submit"
+              className="px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors"
+            >
+              Save
+            </button>
+            <button
+              type="button"
+              onClick={() => setEditingRole(null)}
+              className="px-4 py-2 rounded-lg border border-border text-sm text-muted-foreground hover:bg-muted transition-colors"
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      )}
+
+      {/* Role cards */}
+      <div className="space-y-3">
+        {roles.length === 0 ? (
+          <p className="text-sm text-muted-foreground text-center py-8">No roles found.</p>
+        ) : (
+          roles.map((role) => (
+            <div
+              key={role.id}
+              className="p-4 rounded-lg border border-border bg-muted/20 space-y-2"
+            >
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-semibold text-foreground capitalize">
+                    {role.name}
+                  </span>
+                  {role.isBuiltin && (
+                    <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-muted text-xs font-medium text-muted-foreground">
+                      <Lock className="h-3 w-3" />
+                      Built-in
+                    </span>
+                  )}
+                  <span className="inline-block px-2 py-0.5 rounded-full bg-primary/10 text-xs font-medium text-primary">
+                    {role.userCount} user{role.userCount !== 1 ? "s" : ""}
+                  </span>
+                </div>
+                {!role.isBuiltin && (
+                  <div className="flex items-center gap-1">
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setEditingRole(role);
+                        setEditName(role.name);
+                        setEditDescription(role.description);
+                        setEditPermissions([...role.permissions]);
+                      }}
+                      className="p-1.5 rounded-lg hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+                      title="Edit role"
+                    >
+                      <Pencil className="h-4 w-4" />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleDelete(role)}
+                      className="p-1.5 rounded-lg hover:bg-destructive/10 text-muted-foreground hover:text-destructive transition-colors"
+                      title="Delete role"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </button>
+                  </div>
+                )}
+              </div>
+              {role.description && (
+                <p className="text-xs text-muted-foreground">{role.description}</p>
+              )}
+              <div className="flex flex-wrap gap-1.5">
+                {role.permissions.map((perm) => (
+                  <span
+                    key={perm}
+                    className="inline-block px-2 py-0.5 rounded-full bg-muted text-xs font-mono text-muted-foreground"
+                  >
+                    {perm}
+                  </span>
+                ))}
               </div>
             </div>
           ))

--- a/apps/web/src/components/settings/settings-dialog.tsx
+++ b/apps/web/src/components/settings/settings-dialog.tsx
@@ -158,6 +158,7 @@ interface ApiKeyEntry {
   name: string;
   prefix: string;
   createdAt: string;
+  permissions: string[] | null;
 }
 
 interface UserEntry {
@@ -934,8 +935,9 @@ function PeopleSection() {
               onChange={(e) => setNewRole(e.target.value)}
               className="px-3 py-2 rounded-lg border border-border bg-background text-sm text-foreground"
             >
-              <option value="user">User</option>
-              <option value="admin">Admin</option>
+              <option value="user">User — Basic tool access</option>
+              <option value="editor">Editor — All files &amp; pipelines</option>
+              <option value="admin">Admin — Full access</option>
             </select>
             <select
               value={newTeam}
@@ -984,8 +986,9 @@ function PeopleSection() {
               onChange={(e) => setEditRole(e.target.value)}
               className="px-3 py-2 rounded-lg border border-border bg-background text-sm text-foreground"
             >
-              <option value="user">User</option>
-              <option value="admin">Admin</option>
+              <option value="user">User — Basic tool access</option>
+              <option value="editor">Editor — All files &amp; pipelines</option>
+              <option value="admin">Admin — Full access</option>
             </select>
             <select
               value={editTeam}
@@ -1178,6 +1181,9 @@ function ApiKeysSection() {
   const [copied, setCopied] = useState(false);
   const [generating, setGenerating] = useState(false);
   const [keyName, setKeyName] = useState("");
+  const [showScoping, setShowScoping] = useState(false);
+  const [scopedPerms, setScopedPerms] = useState<string[]>([]);
+  const { permissions } = useAuth();
 
   const loadKeys = useCallback(async () => {
     try {
@@ -1198,18 +1204,22 @@ function ApiKeysSection() {
     setGenerating(true);
     setNewKey(null);
     try {
-      const data = await apiPost<{ key: string }>("/v1/api-keys", {
-        name: keyName || "default",
-      });
+      const payload: Record<string, unknown> = { name: keyName || "default" };
+      if (showScoping && scopedPerms.length > 0) {
+        payload.permissions = scopedPerms;
+      }
+      const data = await apiPost<{ key: string }>("/v1/api-keys", payload);
       setNewKey(data.key);
       setKeyName("");
+      setScopedPerms([]);
+      setShowScoping(false);
       await loadKeys();
     } catch {
       // Silently fail
     } finally {
       setGenerating(false);
     }
-  }, [keyName, loadKeys]);
+  }, [keyName, showScoping, scopedPerms, loadKeys]);
 
   const copyKey = useCallback(async (key: string) => {
     const ok = await copyToClipboard(key);
@@ -1269,6 +1279,39 @@ function ApiKeysSection() {
         </button>
       </div>
 
+      {/* Permission scoping */}
+      <div className="space-y-2">
+        <button
+          type="button"
+          onClick={() => setShowScoping(!showScoping)}
+          className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+        >
+          {showScoping ? "Remove permission scoping" : "Restrict permissions (optional)"}
+        </button>
+
+        {showScoping && (
+          <div className="flex flex-wrap gap-2 p-3 rounded-lg border border-border bg-muted/20">
+            {permissions.map((perm) => (
+              <label key={perm} className="flex items-center gap-1.5 text-xs cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={scopedPerms.includes(perm)}
+                  onChange={(e) => {
+                    if (e.target.checked) {
+                      setScopedPerms([...scopedPerms, perm]);
+                    } else {
+                      setScopedPerms(scopedPerms.filter((p) => p !== perm));
+                    }
+                  }}
+                  className="rounded border-border"
+                />
+                <span className="font-mono">{perm}</span>
+              </label>
+            ))}
+          </div>
+        )}
+      </div>
+
       {/* Newly generated key display */}
       {newKey && (
         <div className="space-y-2">
@@ -1305,6 +1348,11 @@ function ApiKeysSection() {
                 <p className="text-xs text-muted-foreground font-mono">
                   {k.prefix}... &middot; Created {new Date(k.createdAt).toLocaleDateString()}
                 </p>
+                {k.permissions && (
+                  <p className="text-xs text-muted-foreground font-mono mt-0.5">
+                    Scoped: {k.permissions.join(", ")}
+                  </p>
+                )}
               </div>
               <button
                 type="button"

--- a/packages/shared/src/permissions.ts
+++ b/packages/shared/src/permissions.ts
@@ -10,6 +10,9 @@ export type Permission =
   | "settings:write"
   | "users:manage"
   | "teams:manage"
-  | "branding:manage";
+  | "branding:manage"
+  | "features:manage"
+  | "system:health"
+  | "audit:read";
 
-export type Role = "admin" | "user";
+export type Role = "admin" | "editor" | "user";

--- a/tests/e2e/rbac-full.spec.ts
+++ b/tests/e2e/rbac-full.spec.ts
@@ -1,0 +1,332 @@
+import { test as base, expect } from "@playwright/test";
+import { login } from "./helpers";
+
+const API = process.env.API_URL || "http://localhost:13490";
+
+// Unique suffix to avoid collisions with parallel test runs
+const UID = Date.now().toString(36);
+
+/** Auth header only (GET, DELETE). */
+function authOnly(token: string): Record<string, string> {
+  return { Authorization: `Bearer ${token}` };
+}
+
+/** Auth + JSON content-type (POST, PUT). */
+function authJson(token: string): Record<string, string> {
+  return { Authorization: `Bearer ${token}`, "Content-Type": "application/json" };
+}
+
+async function getAdminToken(): Promise<string> {
+  const res = await fetch(`${API}/api/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ username: "admin", password: "admin" }),
+  });
+  const data = await res.json();
+  return data.token;
+}
+
+/** Create a custom role via API. Returns the role id. */
+async function createCustomRole(
+  adminToken: string,
+  name: string,
+  permissions: string[],
+  description = "",
+): Promise<string> {
+  const res = await fetch(`${API}/api/v1/roles`, {
+    method: "POST",
+    headers: authJson(adminToken),
+    body: JSON.stringify({ name, permissions, description }),
+  });
+  if (res.status === 409) {
+    // Role already exists — look it up
+    const listRes = await fetch(`${API}/api/v1/roles`, {
+      headers: authOnly(adminToken),
+    });
+    const { roles } = await listRes.json();
+    const existing = roles.find((r: { name: string }) => r.name === name);
+    return existing?.id ?? "";
+  }
+  if (!res.ok) throw new Error(`Failed to create role: ${res.status}`);
+  const data = await res.json();
+  return data.id;
+}
+
+/** Create a user with a given role and clear mustChangePassword. */
+async function createUserWithRole(
+  adminToken: string,
+  username: string,
+  password: string,
+  role: string,
+): Promise<void> {
+  const createRes = await fetch(`${API}/api/auth/register`, {
+    method: "POST",
+    headers: authJson(adminToken),
+    body: JSON.stringify({ username, password, role }),
+  });
+  if (createRes.status !== 201 && createRes.status !== 409) {
+    throw new Error(`Failed to create user ${username}: ${createRes.status}`);
+  }
+
+  // Login as the user to get a token, then change password to clear mustChangePassword
+  const loginRes = await fetch(`${API}/api/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ username, password }),
+  });
+  if (!loginRes.ok) throw new Error(`Failed to login as ${username}: ${loginRes.status}`);
+  const loginData = await loginRes.json();
+
+  const changeRes = await fetch(`${API}/api/auth/change-password`, {
+    method: "POST",
+    headers: authJson(loginData.token),
+    body: JSON.stringify({ currentPassword: password, newPassword: password }),
+  });
+  if (!changeRes.ok) {
+    throw new Error(`Failed to clear mustChangePassword for ${username}: ${changeRes.status}`);
+  }
+}
+
+/** Delete a user by username if it exists. */
+async function deleteUserByUsername(adminToken: string, username: string): Promise<void> {
+  const listRes = await fetch(`${API}/api/auth/users`, {
+    headers: authOnly(adminToken),
+  });
+  if (!listRes.ok) return;
+  const { users } = await listRes.json();
+  const found = users.find((u: { username: string }) => u.username === username);
+  if (found) {
+    await fetch(`${API}/api/auth/users/${found.id}`, {
+      method: "DELETE",
+      headers: authOnly(adminToken),
+    });
+  }
+}
+
+/** Delete a custom role by name if it exists. */
+async function deleteRoleByName(adminToken: string, name: string): Promise<void> {
+  const listRes = await fetch(`${API}/api/v1/roles`, {
+    headers: authOnly(adminToken),
+  });
+  if (!listRes.ok) return;
+  const { roles } = await listRes.json();
+  const found = roles.find((r: { name: string; isBuiltin: boolean }) => r.name === name);
+  if (found && !found.isBuiltin) {
+    await fetch(`${API}/api/v1/roles/${found.id}`, {
+      method: "DELETE",
+      headers: authOnly(adminToken),
+    });
+  }
+}
+
+// ── 1. People Management UI — role dropdown ─────────────────────────
+
+base.describe("RBAC Full — People Management UI", () => {
+  base.use({
+    storageState: "test-results/.auth/user.json",
+  });
+
+  base.test(
+    "admin sees role dropdown with admin/editor/user options when adding members",
+    async ({ page }) => {
+      await page.goto("/");
+      await page.locator("aside").getByText("Settings").click();
+      await page.getByRole("button", { name: /people/i }).click();
+
+      // Click "Add Members" to reveal the form
+      await page.getByRole("button", { name: /add members/i }).click();
+
+      // The role select should be visible inside the add-user form
+      const roleSelect = page.locator("form select").first();
+      await expect(roleSelect).toBeVisible();
+
+      // Verify the dropdown contains built-in role options (admin, editor, user)
+      const options = roleSelect.locator("option");
+      const optionTexts = await options.allTextContents();
+      const lower = optionTexts.map((t) => t.toLowerCase());
+
+      expect(lower.some((t) => t.includes("admin"))).toBe(true);
+      expect(lower.some((t) => t.includes("editor"))).toBe(true);
+      expect(lower.some((t) => t.includes("user"))).toBe(true);
+    },
+  );
+});
+
+// ── 2–3. Roles Management UI ────────────────────────────────────────
+
+base.describe("RBAC Full — Roles Management UI", () => {
+  base.use({
+    storageState: "test-results/.auth/user.json",
+  });
+
+  base.test("admin sees Roles tab in settings", async ({ page }) => {
+    await page.goto("/");
+    await page.locator("aside").getByText("Settings").click();
+
+    await expect(page.getByRole("button", { name: /^roles$/i })).toBeVisible();
+  });
+
+  base.test("roles section shows built-in roles with Built-in badge", async ({ page }) => {
+    await page.goto("/");
+    await page.locator("aside").getByText("Settings").click();
+    await page.getByRole("button", { name: /^roles$/i }).click();
+
+    // Wait for roles to load
+    await expect(page.getByText("Manage roles and their permissions")).toBeVisible();
+
+    // At least one "Built-in" badge should appear (admin, editor, user are built-in)
+    const builtinBadges = page.getByText("Built-in");
+    await expect(builtinBadges.first()).toBeVisible();
+
+    // Verify at least the three default built-in roles are present
+    await expect(page.getByText("admin").first()).toBeVisible();
+    await expect(page.getByText("editor").first()).toBeVisible();
+    await expect(page.getByText("user").first()).toBeVisible();
+  });
+});
+
+// ── 4–5. Audit Log UI ──────────────────────────────────────────────
+
+base.describe("RBAC Full — Audit Log UI", () => {
+  base.use({
+    storageState: "test-results/.auth/user.json",
+  });
+
+  base.test("admin sees Audit Log tab in settings", async ({ page }) => {
+    await page.goto("/");
+    await page.locator("aside").getByText("Settings").click();
+
+    await expect(page.getByRole("button", { name: /audit log/i })).toBeVisible();
+  });
+
+  base.test("audit log displays LOGIN_SUCCESS entries", async ({ page }) => {
+    await page.goto("/");
+    await page.locator("aside").getByText("Settings").click();
+    await page.getByRole("button", { name: /audit log/i }).click();
+
+    // Wait for audit log section to load
+    await expect(page.locator("h3").filter({ hasText: "Audit Log" })).toBeVisible();
+
+    // The admin login from auth.setup should have created at least one LOGIN_SUCCESS entry.
+    // Filter by LOGIN_SUCCESS action using the dropdown.
+    const filterSelect = page.locator("select").first();
+    await filterSelect.selectOption("LOGIN_SUCCESS");
+
+    // Wait for table to update — check for at least one row with "LOGIN SUCCESS" text
+    // The action column displays the action with underscores replaced by spaces
+    await expect(page.locator("table tbody tr").first()).toBeVisible({ timeout: 10_000 });
+
+    // Verify the table contains LOGIN_SUCCESS (displayed as "LOGIN SUCCESS" or "LOGIN_SUCCESS")
+    const tableText = await page.locator("table tbody").textContent();
+    expect(tableText).toContain("LOGIN");
+  });
+});
+
+// ── 6. API Key Scoping UI ──────────────────────────────────────────
+
+base.describe("RBAC Full — API Key Scoping UI", () => {
+  base.use({
+    storageState: "test-results/.auth/user.json",
+  });
+
+  base.test("API Keys section has permission scoping toggle", async ({ page }) => {
+    await page.goto("/");
+    await page.locator("aside").getByText("Settings").click();
+    await page.getByRole("button", { name: /api keys/i }).click();
+
+    // The scoping toggle text should be visible
+    const scopingToggle = page.getByText("Restrict permissions (optional)");
+    await expect(scopingToggle).toBeVisible();
+
+    // Click the toggle to expand the permission scoping checkboxes
+    await scopingToggle.click();
+
+    // After expanding, the "Remove permission scoping" text should appear
+    await expect(page.getByText("Remove permission scoping")).toBeVisible();
+
+    // Permission checkboxes should appear (e.g., tools:use, files:own)
+    await expect(page.locator("input[type='checkbox']").first()).toBeVisible();
+    await expect(page.getByText("tools:use")).toBeVisible();
+  });
+});
+
+// ── 7–8. Custom Role User ──────────────────────────────────────────
+
+base.describe("RBAC Full — Custom Role User", () => {
+  const CUSTOM_ROLE = `testrole-${UID}`;
+  const CUSTOM_USER = `customuser-${UID}`;
+  const CUSTOM_PASSWORD = "CustomPass1";
+  let adminToken: string;
+
+  base.beforeAll(async () => {
+    adminToken = await getAdminToken();
+
+    // Create a custom role with only settings:read and tools:use permissions
+    await createCustomRole(
+      adminToken,
+      CUSTOM_ROLE,
+      ["settings:read", "tools:use"],
+      "E2E test role",
+    );
+
+    // Create a user with that custom role
+    await createUserWithRole(adminToken, CUSTOM_USER, CUSTOM_PASSWORD, CUSTOM_ROLE);
+  });
+
+  base.afterAll(async () => {
+    // Clean up: delete user first, then role
+    await deleteUserByUsername(adminToken, CUSTOM_USER);
+    await deleteRoleByName(adminToken, CUSTOM_ROLE);
+  });
+
+  base.test("custom role user only sees permitted tabs (no admin tabs)", async ({ page }) => {
+    await login(page, CUSTOM_USER, CUSTOM_PASSWORD);
+
+    await page.locator("aside").getByText("Settings").click();
+
+    // Should see these tabs (available to all authenticated users or matching permissions)
+    await expect(page.getByRole("button", { name: /general/i })).toBeVisible();
+    await expect(page.getByRole("button", { name: /security/i })).toBeVisible();
+    await expect(page.getByRole("button", { name: /api keys/i })).toBeVisible();
+    await expect(page.getByRole("button", { name: /tools/i })).toBeVisible();
+    await expect(page.getByRole("button", { name: /about/i })).toBeVisible();
+
+    // Should NOT see admin-only tabs (requires users:manage, teams:manage, etc.)
+    await expect(page.getByRole("button", { name: /system settings/i })).not.toBeVisible();
+    await expect(page.getByRole("button", { name: /people/i })).not.toBeVisible();
+    await expect(page.getByRole("button", { name: /teams/i })).not.toBeVisible();
+    await expect(page.getByRole("button", { name: /^roles$/i })).not.toBeVisible();
+  });
+
+  base.test(
+    "custom role user gets correct API permissions (settings:read OK, settings:write 403)",
+    async ({ page }) => {
+      await login(page, CUSTOM_USER, CUSTOM_PASSWORD);
+
+      // Extract token from localStorage
+      const token = await page.evaluate(() => localStorage.getItem("ashim-token"));
+      expect(token).toBeTruthy();
+      const bearerToken = token as string;
+
+      // GET /api/v1/settings — requires auth only, should succeed
+      const readRes = await fetch(`${API}/api/v1/settings`, {
+        headers: authOnly(bearerToken),
+      });
+      expect(readRes.status).toBe(200);
+
+      // PUT /api/v1/settings — requires settings:write, should be 403
+      const writeRes = await fetch(`${API}/api/v1/settings`, {
+        method: "PUT",
+        headers: authJson(bearerToken),
+        body: JSON.stringify({ appName: "hacked" }),
+      });
+      expect(writeRes.status).toBe(403);
+
+      // GET /api/auth/users — requires users:manage, should be 403
+      const usersRes = await fetch(`${API}/api/auth/users`, {
+        headers: authOnly(bearerToken),
+      });
+      expect(usersRes.status).toBe(403);
+    },
+  );
+});

--- a/tests/e2e/rbac.spec.ts
+++ b/tests/e2e/rbac.spec.ts
@@ -138,6 +138,9 @@ base.describe("RBAC - User sees restricted tabs", () => {
     await expect(page.getByRole("button", { name: /system settings/i })).not.toBeVisible();
     await expect(page.getByRole("button", { name: /people/i })).not.toBeVisible();
     await expect(page.getByRole("button", { name: /teams/i })).not.toBeVisible();
+
+    // Should NOT see editor-only tabs (requires settings:write)
+    await expect(page.getByRole("button", { name: /ai features/i })).not.toBeVisible();
   });
 
   base.test("user role gets 403 on admin API endpoints", async ({ page }) => {
@@ -158,6 +161,99 @@ base.describe("RBAC - User sees restricted tabs", () => {
     const settingsRes = await fetch(`${API}/api/v1/settings`, {
       method: "PUT",
       headers: authJson(bearerToken),
+      body: JSON.stringify({ appName: "hacked" }),
+    });
+    expect(settingsRes.status).toBe(403);
+  });
+});
+
+// ── Editor sees collaborative tabs ─────────────────────────────────
+
+base.describe("RBAC - Editor sees collaborative tabs", () => {
+  let adminToken: string;
+
+  base.beforeAll(async () => {
+    adminToken = await getAdminToken();
+    // Create editor user
+    const createRes = await fetch(`${API}/api/auth/register`, {
+      method: "POST",
+      headers: authJson(adminToken),
+      body: JSON.stringify({
+        username: "editortest",
+        password: "EditorTest1",
+        role: "editor",
+      }),
+    });
+    if (createRes.status !== 201 && createRes.status !== 409) {
+      throw new Error(`Failed to create editor user: ${createRes.status}`);
+    }
+
+    // Clear mustChangePassword
+    const loginRes = await fetch(`${API}/api/auth/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ username: "editortest", password: "EditorTest1" }),
+    });
+    if (!loginRes.ok) throw new Error(`Editor login failed: ${loginRes.status}`);
+    const loginData = await loginRes.json();
+    await fetch(`${API}/api/auth/change-password`, {
+      method: "POST",
+      headers: authJson(loginData.token),
+      body: JSON.stringify({
+        currentPassword: "EditorTest1",
+        newPassword: "EditorTest1",
+      }),
+    });
+  });
+
+  base.afterAll(async () => {
+    const listRes = await fetch(`${API}/api/auth/users`, {
+      headers: authOnly(adminToken),
+    });
+    if (!listRes.ok) return;
+    const { users } = await listRes.json();
+    const editor = users.find((u: { username: string }) => u.username === "editortest");
+    if (editor) {
+      await fetch(`${API}/api/auth/users/${editor.id}`, {
+        method: "DELETE",
+        headers: authOnly(adminToken),
+      });
+    }
+  });
+
+  base.test(
+    "editor sees general, security, api-keys, tools, about but not admin tabs",
+    async ({ page }) => {
+      await login(page, "editortest", "EditorTest1");
+      await page.locator("aside").getByText("Settings").click();
+
+      // Should see these
+      await expect(page.getByRole("button", { name: /general/i })).toBeVisible();
+      await expect(page.getByRole("button", { name: /security/i })).toBeVisible();
+      await expect(page.getByRole("button", { name: /api keys/i })).toBeVisible();
+      await expect(page.getByRole("button", { name: /tools/i })).toBeVisible();
+      await expect(page.getByRole("button", { name: /about/i })).toBeVisible();
+
+      // Should NOT see admin tabs
+      await expect(page.getByRole("button", { name: /system settings/i })).not.toBeVisible();
+      await expect(page.getByRole("button", { name: /people/i })).not.toBeVisible();
+      await expect(page.getByRole("button", { name: /teams/i })).not.toBeVisible();
+    },
+  );
+
+  base.test("editor gets 403 on admin API endpoints", async ({ page }) => {
+    await login(page, "editortest", "EditorTest1");
+    const token = await page.evaluate(() => localStorage.getItem("ashim-token"));
+    expect(token).toBeTruthy();
+
+    const usersRes = await fetch(`${API}/api/auth/users`, {
+      headers: authOnly(token as string),
+    });
+    expect(usersRes.status).toBe(403);
+
+    const settingsRes = await fetch(`${API}/api/v1/settings`, {
+      method: "PUT",
+      headers: authJson(token as string),
       body: JSON.stringify({ appName: "hacked" }),
     });
     expect(settingsRes.status).toBe(403);

--- a/tests/integration/api-key-edge-cases.test.ts
+++ b/tests/integration/api-key-edge-cases.test.ts
@@ -1,0 +1,225 @@
+/**
+ * API key edge-case tests — name validation, delete behavior, key revocation.
+ */
+
+import { eq } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { db, schema } from "../../apps/api/src/db/index.js";
+import { buildTestApp, loginAsAdmin, type TestApp } from "./test-server.js";
+
+let testApp: TestApp;
+let adminToken: string;
+
+const uid = () => `akec_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`;
+
+beforeAll(async () => {
+  testApp = await buildTestApp();
+  adminToken = await loginAsAdmin(testApp.app);
+}, 30_000);
+
+afterAll(async () => {
+  await testApp.cleanup();
+}, 10_000);
+
+// Helper: register a user, clear mustChangePassword, return credentials + token
+async function createUserAndLogin(
+  opts: { role?: string } = {},
+): Promise<{ username: string; password: string; id: string; token: string }> {
+  const username = uid();
+  const password = "ValidPass1";
+  const regRes = await testApp.app.inject({
+    method: "POST",
+    url: "/api/auth/register",
+    headers: { authorization: `Bearer ${adminToken}` },
+    payload: { username, password, ...opts },
+  });
+  if (regRes.statusCode !== 201) {
+    throw new Error(`createUserAndLogin register failed: ${regRes.statusCode} ${regRes.body}`);
+  }
+  const regBody = JSON.parse(regRes.body);
+
+  db.update(schema.users)
+    .set({ mustChangePassword: false })
+    .where(eq(schema.users.username, username))
+    .run();
+
+  const loginRes = await testApp.app.inject({
+    method: "POST",
+    url: "/api/auth/login",
+    payload: { username, password },
+  });
+  const loginBody = JSON.parse(loginRes.body);
+  if (!loginBody.token) {
+    throw new Error(`createUserAndLogin login failed: ${loginRes.body}`);
+  }
+
+  return { username, password, id: regBody.id, token: loginBody.token };
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Creation validation
+// ═══════════════════════════════════════════════════════════════════════════
+describe("API key creation validation", () => {
+  it("rejects name longer than 100 chars", async () => {
+    const longName = "x".repeat(101);
+    const res = await testApp.app.inject({
+      method: "POST",
+      url: "/api/v1/api-keys",
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { name: longName },
+    });
+    expect(res.statusCode).toBe(400);
+    const body = JSON.parse(res.body);
+    expect(body.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("uses default name when body is empty", async () => {
+    const res = await testApp.app.inject({
+      method: "POST",
+      url: "/api/v1/api-keys",
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: {},
+    });
+    expect(res.statusCode).toBe(201);
+    const body = JSON.parse(res.body);
+    expect(body.name).toBe("Default API Key");
+  });
+
+  it("trims whitespace from name", async () => {
+    const res = await testApp.app.inject({
+      method: "POST",
+      url: "/api/v1/api-keys",
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { name: "  padded-name  " },
+    });
+    expect(res.statusCode).toBe(201);
+    const body = JSON.parse(res.body);
+    expect(body.name).toBe("padded-name");
+  });
+
+  it("returns raw key starting with si_ only on creation", async () => {
+    const createRes = await testApp.app.inject({
+      method: "POST",
+      url: "/api/v1/api-keys",
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { name: "raw-key-check" },
+    });
+    expect(createRes.statusCode).toBe(201);
+    const createBody = JSON.parse(createRes.body);
+    expect(createBody.key).toBeDefined();
+    expect(createBody.key.startsWith("si_")).toBe(true);
+
+    // GET list must NOT include the raw key
+    const listRes = await testApp.app.inject({
+      method: "GET",
+      url: "/api/v1/api-keys",
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    const listBody = JSON.parse(listRes.body);
+    const match = listBody.apiKeys.find((k: any) => k.id === createBody.id);
+    expect(match).toBeDefined();
+    expect(match.key).toBeUndefined();
+  });
+
+  it("rejects invalid expiresAt format", async () => {
+    const res = await testApp.app.inject({
+      method: "POST",
+      url: "/api/v1/api-keys",
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { name: "bad-date-key", expiresAt: "not-a-date" },
+    });
+    expect(res.statusCode).toBe(400);
+    const body = JSON.parse(res.body);
+    expect(body.code).toBe("VALIDATION_ERROR");
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Delete behavior
+// ═══════════════════════════════════════════════════════════════════════════
+describe("API key delete behavior", () => {
+  it("user can delete own key", async () => {
+    const createRes = await testApp.app.inject({
+      method: "POST",
+      url: "/api/v1/api-keys",
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { name: "delete-me" },
+    });
+    const keyId = JSON.parse(createRes.body).id;
+
+    const delRes = await testApp.app.inject({
+      method: "DELETE",
+      url: `/api/v1/api-keys/${keyId}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(delRes.statusCode).toBe(200);
+    const body = JSON.parse(delRes.body);
+    expect(body.ok).toBe(true);
+  });
+
+  it("user cannot delete another user's key", async () => {
+    // Admin creates a key
+    const adminKeyRes = await testApp.app.inject({
+      method: "POST",
+      url: "/api/v1/api-keys",
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { name: "admin-owned-key" },
+    });
+    const adminKeyId = JSON.parse(adminKeyRes.body).id;
+
+    // Create a separate user
+    const other = await createUserAndLogin({ role: "user" });
+
+    // Other user tries to delete admin's key
+    const delRes = await testApp.app.inject({
+      method: "DELETE",
+      url: `/api/v1/api-keys/${adminKeyId}`,
+      headers: { authorization: `Bearer ${other.token}` },
+    });
+    expect(delRes.statusCode).toBe(404);
+  });
+
+  it("delete non-existent key returns 404", async () => {
+    const res = await testApp.app.inject({
+      method: "DELETE",
+      url: "/api/v1/api-keys/00000000-0000-0000-0000-000000000000",
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("deleted key stops working immediately", async () => {
+    // Create a key and verify it works
+    const createRes = await testApp.app.inject({
+      method: "POST",
+      url: "/api/v1/api-keys",
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { name: "revoke-test-key" },
+    });
+    const { id: keyId, key: rawKey } = JSON.parse(createRes.body);
+
+    // Use the key — should succeed
+    const beforeRes = await testApp.app.inject({
+      method: "GET",
+      url: "/api/v1/settings",
+      headers: { authorization: `Bearer ${rawKey}` },
+    });
+    expect(beforeRes.statusCode).toBe(200);
+
+    // Delete the key
+    const delRes = await testApp.app.inject({
+      method: "DELETE",
+      url: `/api/v1/api-keys/${keyId}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(delRes.statusCode).toBe(200);
+
+    // Use the key again — should fail
+    const afterRes = await testApp.app.inject({
+      method: "GET",
+      url: "/api/v1/settings",
+      headers: { authorization: `Bearer ${rawKey}` },
+    });
+    expect(afterRes.statusCode).toBe(401);
+  });
+});

--- a/tests/integration/api-key-scoping.test.ts
+++ b/tests/integration/api-key-scoping.test.ts
@@ -1,0 +1,116 @@
+import { eq } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { db, schema } from "../../apps/api/src/db/index.js";
+import { buildTestApp, loginAsAdmin, type TestApp } from "./test-server.js";
+
+let testApp: TestApp;
+let adminToken: string;
+
+beforeAll(async () => {
+  testApp = await buildTestApp();
+  adminToken = await loginAsAdmin(testApp.app);
+}, 30_000);
+
+afterAll(async () => {
+  await testApp.cleanup();
+}, 10_000);
+
+describe("API key permission scoping", () => {
+  it("creates a key with scoped permissions", async () => {
+    const res = await testApp.app.inject({
+      method: "POST",
+      url: "/api/v1/api-keys",
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { name: "scoped-key", permissions: ["tools:use", "files:own"] },
+    });
+    expect(res.statusCode).toBe(201);
+    const body = JSON.parse(res.body);
+    expect(body.permissions).toEqual(["tools:use", "files:own"]);
+    expect(body.key).toBeTruthy();
+  });
+
+  it("rejects permissions the user does not have", async () => {
+    await testApp.app.inject({
+      method: "POST",
+      url: "/api/auth/register",
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { username: "scopetest", password: "ScopeTest1", role: "user" },
+    });
+    db.update(schema.users)
+      .set({ mustChangePassword: false })
+      .where(eq(schema.users.username, "scopetest"))
+      .run();
+
+    const loginRes = await testApp.app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      payload: { username: "scopetest", password: "ScopeTest1" },
+    });
+    const userToken = JSON.parse(loginRes.body).token;
+
+    const res = await testApp.app.inject({
+      method: "POST",
+      url: "/api/v1/api-keys",
+      headers: { authorization: `Bearer ${userToken}` },
+      payload: { name: "bad-scope", permissions: ["users:manage"] },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("scoped API key is restricted to its permissions", async () => {
+    const createRes = await testApp.app.inject({
+      method: "POST",
+      url: "/api/v1/api-keys",
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { name: "readonly-key", permissions: ["tools:use", "settings:read"] },
+    });
+    const apiKey = JSON.parse(createRes.body).key;
+
+    const settingsRes = await testApp.app.inject({
+      method: "GET",
+      url: "/api/v1/settings",
+      headers: { authorization: `Bearer ${apiKey}` },
+    });
+    expect(settingsRes.statusCode).toBe(200);
+
+    const writeRes = await testApp.app.inject({
+      method: "PUT",
+      url: "/api/v1/settings",
+      headers: { authorization: `Bearer ${apiKey}` },
+      payload: { appName: "hacked" },
+    });
+    expect(writeRes.statusCode).toBe(403);
+  });
+
+  it("null permissions inherits all from user role", async () => {
+    const createRes = await testApp.app.inject({
+      method: "POST",
+      url: "/api/v1/api-keys",
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { name: "full-key" },
+    });
+    const body = JSON.parse(createRes.body);
+    expect(body.permissions).toBeNull();
+
+    const writeRes = await testApp.app.inject({
+      method: "PUT",
+      url: "/api/v1/settings",
+      headers: { authorization: `Bearer ${body.key}` },
+      payload: { testSetting: "value" },
+    });
+    expect(writeRes.statusCode).toBe(200);
+  });
+
+  it("GET /api/v1/api-keys returns permissions field", async () => {
+    const res = await testApp.app.inject({
+      method: "GET",
+      url: "/api/v1/api-keys",
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    const body = JSON.parse(res.body);
+    expect(body.apiKeys.length).toBeGreaterThan(0);
+    const scopedKey = body.apiKeys.find((k: any) => k.name === "scoped-key");
+    expect(scopedKey).toBeDefined();
+    expect(scopedKey.permissions).toEqual(["tools:use", "files:own"]);
+  });
+});

--- a/tests/integration/api-key-scoping.test.ts
+++ b/tests/integration/api-key-scoping.test.ts
@@ -114,3 +114,66 @@ describe("API key permission scoping", () => {
     expect(scopedKey.permissions).toEqual(["tools:use", "files:own"]);
   });
 });
+
+describe("API key expiration", () => {
+  it("creates key with expiration", async () => {
+    const future = new Date(Date.now() + 86400000).toISOString(); // 24h from now
+    const res = await testApp.app.inject({
+      method: "POST",
+      url: "/api/v1/api-keys",
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { name: "expiring-key", expiresAt: future },
+    });
+    expect(res.statusCode).toBe(201);
+    const body = JSON.parse(res.body);
+    expect(body.expiresAt).toBeTruthy();
+  });
+
+  it("rejects past expiration date", async () => {
+    const past = new Date(Date.now() - 86400000).toISOString();
+    const res = await testApp.app.inject({
+      method: "POST",
+      url: "/api/v1/api-keys",
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { name: "past-key", expiresAt: past },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("expired key returns 401", async () => {
+    // Create a key, then manually set its expiration to the past
+    const createRes = await testApp.app.inject({
+      method: "POST",
+      url: "/api/v1/api-keys",
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { name: "will-expire", expiresAt: new Date(Date.now() + 86400000).toISOString() },
+    });
+    const apiKey = JSON.parse(createRes.body).key;
+    const keyId = JSON.parse(createRes.body).id;
+
+    // Manually expire the key in DB
+    db.update(schema.apiKeys)
+      .set({ expiresAt: new Date(Date.now() - 1000) })
+      .where(eq(schema.apiKeys.id, keyId))
+      .run();
+
+    const res = await testApp.app.inject({
+      method: "GET",
+      url: "/api/v1/settings",
+      headers: { authorization: `Bearer ${apiKey}` },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("GET returns expiresAt field", async () => {
+    const res = await testApp.app.inject({
+      method: "GET",
+      url: "/api/v1/api-keys",
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    const body = JSON.parse(res.body);
+    const expiringKey = body.apiKeys.find((k: any) => k.name === "expiring-key");
+    expect(expiringKey).toBeDefined();
+    expect(expiringKey.expiresAt).toBeTruthy();
+  });
+});

--- a/tests/integration/audit-log-edge-cases.test.ts
+++ b/tests/integration/audit-log-edge-cases.test.ts
@@ -1,0 +1,153 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { buildTestApp, loginAsAdmin, type TestApp } from "./test-server.js";
+
+let testApp: TestApp;
+let adminToken: string;
+
+beforeAll(async () => {
+  testApp = await buildTestApp();
+  adminToken = await loginAsAdmin(testApp.app);
+}, 30_000);
+
+afterAll(async () => {
+  await testApp.cleanup();
+}, 10_000);
+
+/* ------------------------------------------------------------------ */
+/*  Helper                                                             */
+/* ------------------------------------------------------------------ */
+
+async function fetchAuditLog(
+  qs = "",
+): Promise<{ entries: any[]; total: number; page: number; limit: number }> {
+  const res = await testApp.app.inject({
+    method: "GET",
+    url: `/api/v1/audit-log${qs ? `?${qs}` : ""}`,
+    headers: { authorization: `Bearer ${adminToken}` },
+  });
+  expect(res.statusCode).toBe(200);
+  return JSON.parse(res.body);
+}
+
+/* ------------------------------------------------------------------ */
+/*  Event recording                                                    */
+/* ------------------------------------------------------------------ */
+
+describe("audit log event recording", () => {
+  it("LOGIN_SUCCESS recorded after login", async () => {
+    const body = await fetchAuditLog("action=LOGIN_SUCCESS");
+    expect(body.entries.length).toBeGreaterThan(0);
+    expect(body.entries[0].action).toBe("LOGIN_SUCCESS");
+  });
+
+  it("USER_CREATED recorded after register", async () => {
+    await testApp.app.inject({
+      method: "POST",
+      url: "/api/auth/register",
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: {
+        username: "audit_edge_user",
+        password: "AuditEdge1",
+        role: "user",
+      },
+    });
+
+    const body = await fetchAuditLog("action=USER_CREATED");
+    expect(body.entries.length).toBeGreaterThan(0);
+    expect(body.entries.some((e: any) => e.action === "USER_CREATED")).toBe(true);
+  });
+
+  it("API_KEY_CREATED recorded after key creation", async () => {
+    await testApp.app.inject({
+      method: "POST",
+      url: "/api/v1/api-keys",
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { name: "audit-edge-key" },
+    });
+
+    const body = await fetchAuditLog("action=API_KEY_CREATED");
+    expect(body.entries.length).toBeGreaterThan(0);
+    expect(body.entries.some((e: any) => e.action === "API_KEY_CREATED")).toBe(true);
+  });
+
+  it("ROLE_CREATED recorded after role creation", async () => {
+    await testApp.app.inject({
+      method: "POST",
+      url: "/api/v1/roles",
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: {
+        name: "audit-edge-role",
+        description: "role for audit edge test",
+        permissions: ["tools:use"],
+      },
+    });
+
+    const body = await fetchAuditLog("action=ROLE_CREATED");
+    expect(body.entries.length).toBeGreaterThan(0);
+    expect(body.entries.some((e: any) => e.action === "ROLE_CREATED")).toBe(true);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  Pagination edge cases                                              */
+/* ------------------------------------------------------------------ */
+
+describe("audit log pagination edge cases", () => {
+  it("page=0 clamped to 1", async () => {
+    const body = await fetchAuditLog("page=0");
+    expect(body.page).toBe(1);
+  });
+
+  it("negative page clamped to 1", async () => {
+    const body = await fetchAuditLog("page=-5");
+    expect(body.page).toBe(1);
+  });
+
+  it("limit=500 clamped to 100", async () => {
+    const body = await fetchAuditLog("limit=500");
+    expect(body.limit).toBe(100);
+  });
+
+  it("limit=0 falls back to default (50)", async () => {
+    const body = await fetchAuditLog("limit=0");
+    expect(body.limit).toBe(50);
+  });
+
+  it("non-numeric values use defaults", async () => {
+    const body = await fetchAuditLog("page=abc&limit=xyz");
+    expect(body.page).toBe(1);
+    expect(body.limit).toBe(50);
+  });
+
+  it("high page number returns empty entries", async () => {
+    const body = await fetchAuditLog("page=99999");
+    expect(body.entries).toEqual([]);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  Entry structure                                                    */
+/* ------------------------------------------------------------------ */
+
+describe("audit log entry structure", () => {
+  it("each entry has id, actorUsername, action, createdAt (valid ISO date)", async () => {
+    const body = await fetchAuditLog("limit=10");
+    expect(body.entries.length).toBeGreaterThan(0);
+
+    for (const entry of body.entries) {
+      expect(entry).toHaveProperty("id");
+      expect(typeof entry.id).toBe("string");
+
+      expect(entry).toHaveProperty("actorUsername");
+      expect(typeof entry.actorUsername).toBe("string");
+
+      expect(entry).toHaveProperty("action");
+      expect(typeof entry.action).toBe("string");
+
+      expect(entry).toHaveProperty("createdAt");
+      expect(typeof entry.createdAt).toBe("string");
+      const parsed = new Date(entry.createdAt);
+      expect(Number.isNaN(parsed.getTime())).toBe(false);
+    }
+  });
+});

--- a/tests/integration/audit-log.test.ts
+++ b/tests/integration/audit-log.test.ts
@@ -1,0 +1,94 @@
+import { eq } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { db, schema } from "../../apps/api/src/db/index.js";
+import { buildTestApp, loginAsAdmin, type TestApp } from "./test-server.js";
+
+let testApp: TestApp;
+let adminToken: string;
+
+beforeAll(async () => {
+  testApp = await buildTestApp();
+  adminToken = await loginAsAdmin(testApp.app);
+}, 30_000);
+
+afterAll(async () => {
+  await testApp.cleanup();
+}, 10_000);
+
+describe("audit log", () => {
+  it("records login events in database", async () => {
+    await testApp.app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      payload: { username: "admin", password: "Adminpass1" },
+    });
+
+    const res = await testApp.app.inject({
+      method: "GET",
+      url: "/api/v1/audit-log",
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.entries).toBeDefined();
+    expect(body.entries.length).toBeGreaterThan(0);
+    expect(body.entries.some((e: any) => e.action === "LOGIN_SUCCESS")).toBe(true);
+  });
+
+  it("requires audit:read permission", async () => {
+    await testApp.app.inject({
+      method: "POST",
+      url: "/api/auth/register",
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: {
+        username: "auditnoread",
+        password: "AuditTest1",
+        role: "user",
+      },
+    });
+    db.update(schema.users)
+      .set({ mustChangePassword: false })
+      .where(eq(schema.users.username, "auditnoread"))
+      .run();
+
+    const loginRes = await testApp.app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      payload: { username: "auditnoread", password: "AuditTest1" },
+    });
+    const userToken = JSON.parse(loginRes.body).token;
+
+    const res = await testApp.app.inject({
+      method: "GET",
+      url: "/api/v1/audit-log",
+      headers: { authorization: `Bearer ${userToken}` },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("supports pagination", async () => {
+    const res = await testApp.app.inject({
+      method: "GET",
+      url: "/api/v1/audit-log?limit=2&page=1",
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.entries.length).toBeLessThanOrEqual(2);
+    expect(body.total).toBeDefined();
+    expect(body.page).toBe(1);
+    expect(body.limit).toBe(2);
+  });
+
+  it("supports action filter", async () => {
+    const res = await testApp.app.inject({
+      method: "GET",
+      url: "/api/v1/audit-log?action=LOGIN_SUCCESS",
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    const body = JSON.parse(res.body);
+    for (const entry of body.entries) {
+      expect(entry.action).toBe("LOGIN_SUCCESS");
+    }
+  });
+});

--- a/tests/integration/auth-edge-cases.test.ts
+++ b/tests/integration/auth-edge-cases.test.ts
@@ -1,0 +1,404 @@
+/**
+ * Auth route edge-case tests — login failures, session expiry,
+ * password-change side effects, register validation.
+ */
+
+import { eq } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { db, schema } from "../../apps/api/src/db/index.js";
+import { buildTestApp, loginAsAdmin, type TestApp } from "./test-server.js";
+
+let testApp: TestApp;
+let adminToken: string;
+
+const uid = () => `auth_test_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`;
+
+beforeAll(async () => {
+  testApp = await buildTestApp();
+  adminToken = await loginAsAdmin(testApp.app);
+}, 30_000);
+
+afterAll(async () => {
+  await testApp.cleanup();
+}, 10_000);
+
+// Helper: register a user, clear mustChangePassword, return { username, password }
+async function createUser(
+  opts: { role?: string; team?: string } = {},
+): Promise<{ username: string; password: string; id: string }> {
+  const username = uid();
+  const password = "ValidPass1";
+  const res = await testApp.app.inject({
+    method: "POST",
+    url: "/api/auth/register",
+    headers: { authorization: `Bearer ${adminToken}` },
+    payload: { username, password, ...opts },
+  });
+  const body = JSON.parse(res.body);
+  if (res.statusCode !== 201) {
+    throw new Error(`createUser failed: ${res.statusCode} ${res.body}`);
+  }
+  db.update(schema.users)
+    .set({ mustChangePassword: false })
+    .where(eq(schema.users.username, username))
+    .run();
+  return { username, password, id: body.id };
+}
+
+// Helper: login and return token
+async function loginAs(username: string, password: string): Promise<string> {
+  const res = await testApp.app.inject({
+    method: "POST",
+    url: "/api/auth/login",
+    payload: { username, password },
+  });
+  const body = JSON.parse(res.body);
+  if (!body.token) throw new Error(`loginAs failed: ${res.body}`);
+  return body.token as string;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// LOGIN FAILURES
+// ═══════════════════════════════════════════════════════════════════════════
+describe("Login failures", () => {
+  it("empty body returns 400", async () => {
+    const res = await testApp.app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      payload: {},
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("missing username returns 400", async () => {
+    const res = await testApp.app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      payload: { password: "Anything1" },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("missing password returns 400", async () => {
+    const res = await testApp.app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      payload: { username: "admin" },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("unknown username returns 401", async () => {
+    const res = await testApp.app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      payload: { username: `nonexistent_${Date.now()}`, password: "Whatever1" },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("wrong password returns 401", async () => {
+    const res = await testApp.app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      payload: { username: "admin", password: "WrongPass1" },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("failed logins generate LOGIN_FAILED audit events", async () => {
+    const marker = uid();
+    // Trigger a failed login with a unique username
+    await testApp.app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      payload: { username: marker, password: "Whatever1" },
+    });
+
+    const res = await testApp.app.inject({
+      method: "GET",
+      url: "/api/v1/audit-log?action=LOGIN_FAILED&limit=50",
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    const match = body.entries.find(
+      (e: any) => e.action === "LOGIN_FAILED" && e.details?.username === marker,
+    );
+    expect(match).toBeDefined();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SESSION EDGE CASES
+// ═══════════════════════════════════════════════════════════════════════════
+describe("Session edge cases", () => {
+  it("no token on session endpoint returns 401", async () => {
+    const res = await testApp.app.inject({
+      method: "GET",
+      url: "/api/auth/session",
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("expired session token returns 401", async () => {
+    // Login to get a valid session
+    const token = await loginAs("admin", "Adminpass1");
+
+    // Manually expire the session in the DB
+    db.update(schema.sessions)
+      .set({ expiresAt: new Date(Date.now() - 60_000) })
+      .where(eq(schema.sessions.id, token))
+      .run();
+
+    const res = await testApp.app.inject({
+      method: "GET",
+      url: "/api/auth/session",
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// PASSWORD CHANGE SIDE EFFECTS
+// ═══════════════════════════════════════════════════════════════════════════
+describe("Password change side effects", () => {
+  it("changing password invalidates other sessions", async () => {
+    const { username, password } = await createUser();
+
+    // Create two sessions
+    const token1 = await loginAs(username, password);
+    const token2 = await loginAs(username, password);
+
+    // Verify both sessions work
+    const check1 = await testApp.app.inject({
+      method: "GET",
+      url: "/api/auth/session",
+      headers: { authorization: `Bearer ${token1}` },
+    });
+    expect(check1.statusCode).toBe(200);
+
+    const check2 = await testApp.app.inject({
+      method: "GET",
+      url: "/api/auth/session",
+      headers: { authorization: `Bearer ${token2}` },
+    });
+    expect(check2.statusCode).toBe(200);
+
+    // Change password via session 1
+    const changeRes = await testApp.app.inject({
+      method: "POST",
+      url: "/api/auth/change-password",
+      headers: { authorization: `Bearer ${token1}` },
+      payload: { currentPassword: password, newPassword: "NewValid1" },
+    });
+    expect(changeRes.statusCode).toBe(200);
+
+    // Session 1 should still work (it's the current session)
+    const after1 = await testApp.app.inject({
+      method: "GET",
+      url: "/api/auth/session",
+      headers: { authorization: `Bearer ${token1}` },
+    });
+    expect(after1.statusCode).toBe(200);
+
+    // Session 2 should now be invalid
+    const after2 = await testApp.app.inject({
+      method: "GET",
+      url: "/api/auth/session",
+      headers: { authorization: `Bearer ${token2}` },
+    });
+    expect(after2.statusCode).toBe(401);
+  });
+
+  it("changing password revokes API keys", async () => {
+    const { username, password } = await createUser();
+    const token = await loginAs(username, password);
+
+    // Create an API key
+    const createKeyRes = await testApp.app.inject({
+      method: "POST",
+      url: "/api/v1/api-keys",
+      headers: { authorization: `Bearer ${token}` },
+      payload: { name: "test-key" },
+    });
+    expect(createKeyRes.statusCode).toBe(201);
+    const apiKey = JSON.parse(createKeyRes.body).key;
+
+    // Verify the key works (hit a public-ish endpoint that still reads auth)
+    const keyCheck = await testApp.app.inject({
+      method: "GET",
+      url: "/api/v1/api-keys",
+      headers: { authorization: `Bearer ${apiKey}` },
+    });
+    expect(keyCheck.statusCode).toBe(200);
+
+    // Change password
+    const changeRes = await testApp.app.inject({
+      method: "POST",
+      url: "/api/auth/change-password",
+      headers: { authorization: `Bearer ${token}` },
+      payload: { currentPassword: password, newPassword: "NewValid2" },
+    });
+    expect(changeRes.statusCode).toBe(200);
+
+    // API key should now be revoked
+    const keyAfter = await testApp.app.inject({
+      method: "GET",
+      url: "/api/v1/api-keys",
+      headers: { authorization: `Bearer ${apiKey}` },
+    });
+    expect(keyAfter.statusCode).toBe(401);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// PASSWORD RESET SIDE EFFECTS (admin resets another user)
+// ═══════════════════════════════════════════════════════════════════════════
+describe("Password reset side effects", () => {
+  it("admin reset invalidates target user sessions", async () => {
+    const { username, password, id } = await createUser();
+    const userToken = await loginAs(username, password);
+
+    // Verify user session works
+    const before = await testApp.app.inject({
+      method: "GET",
+      url: "/api/auth/session",
+      headers: { authorization: `Bearer ${userToken}` },
+    });
+    expect(before.statusCode).toBe(200);
+
+    // Admin resets the user's password
+    const resetRes = await testApp.app.inject({
+      method: "POST",
+      url: `/api/auth/users/${id}/reset-password`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { newPassword: "ResetPass1" },
+    });
+    expect(resetRes.statusCode).toBe(200);
+
+    // User session should now be invalid
+    const after = await testApp.app.inject({
+      method: "GET",
+      url: "/api/auth/session",
+      headers: { authorization: `Bearer ${userToken}` },
+    });
+    expect(after.statusCode).toBe(401);
+  });
+
+  it("admin reset revokes target user API keys", async () => {
+    const { username, password, id } = await createUser();
+    const userToken = await loginAs(username, password);
+
+    // Create an API key for the target user
+    const createKeyRes = await testApp.app.inject({
+      method: "POST",
+      url: "/api/v1/api-keys",
+      headers: { authorization: `Bearer ${userToken}` },
+      payload: { name: "target-key" },
+    });
+    expect(createKeyRes.statusCode).toBe(201);
+    const apiKey = JSON.parse(createKeyRes.body).key;
+
+    // Verify the key works
+    const keyBefore = await testApp.app.inject({
+      method: "GET",
+      url: "/api/v1/api-keys",
+      headers: { authorization: `Bearer ${apiKey}` },
+    });
+    expect(keyBefore.statusCode).toBe(200);
+
+    // Admin resets the user's password
+    const resetRes = await testApp.app.inject({
+      method: "POST",
+      url: `/api/auth/users/${id}/reset-password`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { newPassword: "ResetPass2" },
+    });
+    expect(resetRes.statusCode).toBe(200);
+
+    // API key should now be revoked
+    const keyAfter = await testApp.app.inject({
+      method: "GET",
+      url: "/api/v1/api-keys",
+      headers: { authorization: `Bearer ${apiKey}` },
+    });
+    expect(keyAfter.statusCode).toBe(401);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// REGISTER VALIDATION
+// ═══════════════════════════════════════════════════════════════════════════
+describe("Register validation", () => {
+  it("invalid username chars returns 400", async () => {
+    const res = await testApp.app.inject({
+      method: "POST",
+      url: "/api/auth/register",
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { username: "bad user!@#", password: "ValidPass1" },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).code).toBe("VALIDATION_ERROR");
+  });
+
+  it("username too short (2 chars) returns 400", async () => {
+    const res = await testApp.app.inject({
+      method: "POST",
+      url: "/api/auth/register",
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { username: "ab", password: "ValidPass1" },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).code).toBe("VALIDATION_ERROR");
+  });
+
+  it("weak password returns 400", async () => {
+    const res = await testApp.app.inject({
+      method: "POST",
+      url: "/api/auth/register",
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { username: uid(), password: "weak" },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).code).toBe("VALIDATION_ERROR");
+  });
+
+  it("non-existent team name returns 400", async () => {
+    const res = await testApp.app.inject({
+      method: "POST",
+      url: "/api/auth/register",
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: {
+        username: uid(),
+        password: "ValidPass1",
+        team: `ghost_team_${Date.now()}`,
+      },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).code).toBe("VALIDATION_ERROR");
+  });
+
+  it("unknown role defaults to user", async () => {
+    const username = uid();
+    const res = await testApp.app.inject({
+      method: "POST",
+      url: "/api/auth/register",
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { username, password: "ValidPass1", role: "bogus" },
+    });
+    expect(res.statusCode).toBe(201);
+    const body = JSON.parse(res.body);
+    expect(body.role).toBe("user");
+  });
+
+  it("delete non-existent user returns 404", async () => {
+    const res = await testApp.app.inject({
+      method: "DELETE",
+      url: "/api/auth/users/00000000-0000-0000-0000-000000000000",
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+});

--- a/tests/integration/custom-roles-edge-cases.test.ts
+++ b/tests/integration/custom-roles-edge-cases.test.ts
@@ -1,0 +1,280 @@
+import { eq } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { db, schema } from "../../apps/api/src/db/index.js";
+import { buildTestApp, loginAsAdmin, type TestApp } from "./test-server.js";
+
+let testApp: TestApp;
+let adminToken: string;
+
+beforeAll(async () => {
+  testApp = await buildTestApp();
+  adminToken = await loginAsAdmin(testApp.app);
+}, 30_000);
+
+afterAll(async () => {
+  await testApp.cleanup();
+}, 10_000);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Create a custom role and return its id. */
+async function createRole(
+  name: string,
+  permissions: string[],
+  description?: string,
+): Promise<string> {
+  const res = await testApp.app.inject({
+    method: "POST",
+    url: "/api/v1/roles",
+    headers: { authorization: `Bearer ${adminToken}` },
+    payload: { name, permissions, description },
+  });
+  const body = JSON.parse(res.body);
+  if (res.statusCode !== 201) {
+    throw new Error(`createRole failed (${res.statusCode}): ${res.body}`);
+  }
+  return body.id as string;
+}
+
+/** Register a user, clear mustChangePassword, return a session token. */
+async function createUserAndLogin(
+  username: string,
+  password: string,
+  role: string,
+): Promise<string> {
+  await testApp.app.inject({
+    method: "POST",
+    url: "/api/auth/register",
+    headers: { authorization: `Bearer ${adminToken}` },
+    payload: { username, password, role },
+  });
+  db.update(schema.users)
+    .set({ mustChangePassword: false })
+    .where(eq(schema.users.username, username))
+    .run();
+
+  const loginRes = await testApp.app.inject({
+    method: "POST",
+    url: "/api/auth/login",
+    payload: { username, password },
+  });
+  return JSON.parse(loginRes.body).token as string;
+}
+
+// ---------------------------------------------------------------------------
+// Name validation (5 tests)
+// ---------------------------------------------------------------------------
+describe("name validation", () => {
+  it("rejects name shorter than 2 chars", async () => {
+    const res = await testApp.app.inject({
+      method: "POST",
+      url: "/api/v1/roles",
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { name: "x", permissions: ["tools:use"] },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("rejects name longer than 30 chars", async () => {
+    const res = await testApp.app.inject({
+      method: "POST",
+      url: "/api/v1/roles",
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { name: "a".repeat(31), permissions: ["tools:use"] },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("rejects name with spaces", async () => {
+    const res = await testApp.app.inject({
+      method: "POST",
+      url: "/api/v1/roles",
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { name: "bad role", permissions: ["tools:use"] },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("normalizes uppercase to lowercase", async () => {
+    const suffix = Date.now();
+    const res = await testApp.app.inject({
+      method: "POST",
+      url: "/api/v1/roles",
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { name: `UpperCase${suffix}`, permissions: ["tools:use"] },
+    });
+    expect(res.statusCode).toBe(201);
+    const body = JSON.parse(res.body);
+    expect(body.name).toBe(`uppercase${suffix}`);
+  });
+
+  it("accepts hyphen and underscore", async () => {
+    const suffix = Date.now();
+    const res = await testApp.app.inject({
+      method: "POST",
+      url: "/api/v1/roles",
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { name: `ok-role_${suffix}`, permissions: ["tools:use"] },
+    });
+    expect(res.statusCode).toBe(201);
+    const body = JSON.parse(res.body);
+    expect(body.name).toBe(`ok-role_${suffix}`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Permission validation (3 tests)
+// ---------------------------------------------------------------------------
+describe("permission validation", () => {
+  it("rejects invalid permission names", async () => {
+    const res = await testApp.app.inject({
+      method: "POST",
+      url: "/api/v1/roles",
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { name: `inv-${Date.now()}`, permissions: ["fly:to-moon"] },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toContain("Invalid permissions");
+  });
+
+  it("rejects missing permissions field", async () => {
+    const res = await testApp.app.inject({
+      method: "POST",
+      url: "/api/v1/roles",
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { name: `noperms-${Date.now()}` },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("rejects missing name field", async () => {
+    const res = await testApp.app.inject({
+      method: "POST",
+      url: "/api/v1/roles",
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { permissions: ["tools:use"] },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CRUD edge cases (5 tests)
+// ---------------------------------------------------------------------------
+describe("CRUD edge cases", () => {
+  it("PUT non-existent role returns 404", async () => {
+    const res = await testApp.app.inject({
+      method: "PUT",
+      url: "/api/v1/roles/00000000-0000-0000-0000-000000000000",
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { permissions: ["tools:use"] },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("DELETE non-existent role returns 404", async () => {
+    const res = await testApp.app.inject({
+      method: "DELETE",
+      url: "/api/v1/roles/00000000-0000-0000-0000-000000000000",
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("updates role description", async () => {
+    const id = await createRole(`desc-${Date.now()}`, ["tools:use"], "original");
+    const res = await testApp.app.inject({
+      method: "PUT",
+      url: `/api/v1/roles/${id}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { description: "updated description" },
+    });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("rejects invalid permissions on update", async () => {
+    const id = await createRole(`upd-${Date.now()}`, ["tools:use"]);
+    const res = await testApp.app.inject({
+      method: "PUT",
+      url: `/api/v1/roles/${id}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { permissions: ["nonexistent:perm"] },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toContain("Invalid permissions");
+  });
+
+  it("multiple users on deleted role all get reassigned to user", async () => {
+    const suffix = Date.now();
+    const roleName = `multi-${suffix}`;
+    const roleId = await createRole(roleName, ["tools:use", "files:own"]);
+
+    // Register three users on this role
+    for (let i = 1; i <= 3; i++) {
+      await testApp.app.inject({
+        method: "POST",
+        url: "/api/auth/register",
+        headers: { authorization: `Bearer ${adminToken}` },
+        payload: {
+          username: `multi-u${i}-${suffix}`,
+          password: "TestPass1",
+          role: roleName,
+        },
+      });
+      db.update(schema.users)
+        .set({ mustChangePassword: false })
+        .where(eq(schema.users.username, `multi-u${i}-${suffix}`))
+        .run();
+    }
+
+    // Delete the role
+    const delRes = await testApp.app.inject({
+      method: "DELETE",
+      url: `/api/v1/roles/${roleId}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(delRes.statusCode).toBe(200);
+
+    // Verify all three users were reassigned to "user"
+    for (let i = 1; i <= 3; i++) {
+      const loginRes = await testApp.app.inject({
+        method: "POST",
+        url: "/api/auth/login",
+        payload: { username: `multi-u${i}-${suffix}`, password: "TestPass1" },
+      });
+      const body = JSON.parse(loginRes.body);
+      expect(body.user.role).toBe("user");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Functional permissions (1 test)
+// ---------------------------------------------------------------------------
+describe("functional permissions", () => {
+  it("custom role with only settings:read can read settings but not audit log", async () => {
+    const suffix = Date.now();
+    const roleName = `readonly-${suffix}`;
+    await createRole(roleName, ["settings:read"]);
+
+    const token = await createUserAndLogin(`ro-user-${suffix}`, "ReadOnly1", roleName);
+
+    // Can read settings (GET /api/v1/settings requires only authentication)
+    const settingsRes = await testApp.app.inject({
+      method: "GET",
+      url: "/api/v1/settings",
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(settingsRes.statusCode).toBe(200);
+
+    // Cannot access audit log (requires audit:read permission)
+    const auditRes = await testApp.app.inject({
+      method: "GET",
+      url: "/api/v1/audit-log",
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(auditRes.statusCode).toBe(403);
+  });
+});

--- a/tests/integration/custom-roles.test.ts
+++ b/tests/integration/custom-roles.test.ts
@@ -1,0 +1,160 @@
+import { eq } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { db, schema } from "../../apps/api/src/db/index.js";
+import { buildTestApp, loginAsAdmin, type TestApp } from "./test-server.js";
+
+let testApp: TestApp;
+let adminToken: string;
+
+beforeAll(async () => {
+  testApp = await buildTestApp();
+  adminToken = await loginAsAdmin(testApp.app);
+}, 30_000);
+
+afterAll(async () => {
+  await testApp.cleanup();
+}, 10_000);
+
+describe("custom roles", () => {
+  let customRoleId: string;
+
+  it("lists built-in roles", async () => {
+    const res = await testApp.app.inject({
+      method: "GET",
+      url: "/api/v1/roles",
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.roles.length).toBeGreaterThanOrEqual(3);
+    expect(body.roles.some((r: any) => r.name === "admin" && r.isBuiltin)).toBe(true);
+    expect(body.roles.some((r: any) => r.name === "editor" && r.isBuiltin)).toBe(true);
+    expect(body.roles.some((r: any) => r.name === "user" && r.isBuiltin)).toBe(true);
+  });
+
+  it("creates a custom role", async () => {
+    const res = await testApp.app.inject({
+      method: "POST",
+      url: "/api/v1/roles",
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: {
+        name: "reviewer",
+        description: "Can view all files and pipelines",
+        permissions: ["files:all", "pipelines:all", "settings:read"],
+      },
+    });
+    expect(res.statusCode).toBe(201);
+    const body = JSON.parse(res.body);
+    expect(body.name).toBe("reviewer");
+    expect(body.permissions).toEqual(["files:all", "pipelines:all", "settings:read"]);
+    customRoleId = body.id;
+  });
+
+  it("cannot create duplicate role name", async () => {
+    const res = await testApp.app.inject({
+      method: "POST",
+      url: "/api/v1/roles",
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { name: "admin", permissions: ["tools:use"] },
+    });
+    expect(res.statusCode).toBe(409);
+  });
+
+  it("can assign custom role to user", async () => {
+    await testApp.app.inject({
+      method: "POST",
+      url: "/api/auth/register",
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { username: "customroleuser", password: "CustomRole1", role: "reviewer" },
+    });
+    db.update(schema.users)
+      .set({ mustChangePassword: false })
+      .where(eq(schema.users.username, "customroleuser"))
+      .run();
+
+    const loginRes = await testApp.app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      payload: { username: "customroleuser", password: "CustomRole1" },
+    });
+    const body = JSON.parse(loginRes.body);
+    expect(body.user.role).toBe("reviewer");
+    expect(body.user.permissions).toContain("files:all");
+    expect(body.user.permissions).not.toContain("tools:use");
+  });
+
+  it("updates custom role permissions", async () => {
+    const res = await testApp.app.inject({
+      method: "PUT",
+      url: `/api/v1/roles/${customRoleId}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { permissions: ["files:all", "pipelines:all", "settings:read", "tools:use"] },
+    });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("cannot modify built-in roles", async () => {
+    const listRes = await testApp.app.inject({
+      method: "GET",
+      url: "/api/v1/roles",
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    const builtinRole = JSON.parse(listRes.body).roles.find((r: any) => r.name === "admin");
+    const res = await testApp.app.inject({
+      method: "PUT",
+      url: `/api/v1/roles/${builtinRole.id}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { permissions: ["tools:use"] },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("cannot delete built-in roles", async () => {
+    const listRes = await testApp.app.inject({
+      method: "GET",
+      url: "/api/v1/roles",
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    const builtinRole = JSON.parse(listRes.body).roles.find((r: any) => r.name === "admin");
+    const res = await testApp.app.inject({
+      method: "DELETE",
+      url: `/api/v1/roles/${builtinRole.id}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("deleting custom role reassigns users to user", async () => {
+    const res = await testApp.app.inject({
+      method: "DELETE",
+      url: `/api/v1/roles/${customRoleId}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+
+    const loginRes = await testApp.app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      payload: { username: "customroleuser", password: "CustomRole1" },
+    });
+    const body = JSON.parse(loginRes.body);
+    expect(body.user.role).toBe("user");
+  });
+
+  it("requires users:manage to create roles", async () => {
+    const loginRes = await testApp.app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      payload: { username: "customroleuser", password: "CustomRole1" },
+    });
+    const userToken = JSON.parse(loginRes.body).token;
+
+    const res = await testApp.app.inject({
+      method: "POST",
+      url: "/api/v1/roles",
+      headers: { authorization: `Bearer ${userToken}` },
+      payload: { name: "hacker", permissions: ["users:manage"] },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+});

--- a/tests/integration/escalation.test.ts
+++ b/tests/integration/escalation.test.ts
@@ -1,0 +1,264 @@
+import { eq } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { db, schema } from "../../apps/api/src/db/index.js";
+import { buildTestApp, loginAsAdmin, type TestApp } from "./test-server.js";
+
+let testApp: TestApp;
+let adminToken: string;
+
+const ts = Date.now();
+
+beforeAll(async () => {
+  testApp = await buildTestApp();
+  adminToken = await loginAsAdmin(testApp.app);
+}, 30_000);
+
+afterAll(async () => {
+  await testApp.cleanup();
+}, 10_000);
+
+/**
+ * Helper: register a user via the admin endpoint and return the response.
+ */
+async function registerUser(token: string, username: string, role: string, password = "Testpass1") {
+  return testApp.app.inject({
+    method: "POST",
+    url: "/api/auth/register",
+    headers: { authorization: `Bearer ${token}` },
+    payload: { username, password, role },
+  });
+}
+
+/**
+ * Helper: log in as a given user and return the session token.
+ */
+async function loginAs(username: string, password = "Testpass1"): Promise<string> {
+  db.update(schema.users)
+    .set({ mustChangePassword: false })
+    .where(eq(schema.users.username, username))
+    .run();
+
+  const res = await testApp.app.inject({
+    method: "POST",
+    url: "/api/auth/login",
+    payload: { username, password },
+  });
+  const body = JSON.parse(res.body);
+  if (!body.token) {
+    throw new Error(`loginAs(${username}) failed: ${res.body}`);
+  }
+  return body.token as string;
+}
+
+// ── Register route escalation ─────────────────────────────────────
+
+describe("register route escalation", () => {
+  it("1. admin can create an admin user (201)", async () => {
+    const res = await registerUser(adminToken, `adm_${ts}_1`, "admin");
+    expect(res.statusCode).toBe(201);
+    expect(JSON.parse(res.body).role).toBe("admin");
+  });
+
+  it("2. admin can create an editor user (201)", async () => {
+    const res = await registerUser(adminToken, `edt_${ts}_2`, "editor");
+    expect(res.statusCode).toBe(201);
+    expect(JSON.parse(res.body).role).toBe("editor");
+  });
+
+  it("3. admin can create a regular user (201)", async () => {
+    const res = await registerUser(adminToken, `usr_${ts}_3`, "user");
+    expect(res.statusCode).toBe(201);
+    expect(JSON.parse(res.body).role).toBe("user");
+  });
+
+  it("4. editor cannot register anyone (403 — lacks users:manage)", async () => {
+    await registerUser(adminToken, `edt_${ts}_4`, "editor");
+    const editorToken = await loginAs(`edt_${ts}_4`);
+
+    const res = await registerUser(editorToken, `blocked_${ts}_4`, "user");
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("5. user cannot register anyone (403 — lacks users:manage)", async () => {
+    await registerUser(adminToken, `usr_${ts}_5`, "user");
+    const userToken = await loginAs(`usr_${ts}_5`);
+
+    const res = await registerUser(userToken, `blocked_${ts}_5`, "user");
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("6. unauthenticated cannot register (401)", async () => {
+    const res = await testApp.app.inject({
+      method: "POST",
+      url: "/api/auth/register",
+      payload: { username: `anon_${ts}_6`, password: "Testpass1", role: "user" },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+// ── Update user role escalation ───────────────────────────────────
+
+describe("update user role escalation", () => {
+  let targetUserId: string;
+
+  beforeAll(async () => {
+    const res = await registerUser(adminToken, `target_${ts}_upd`, "user");
+    targetUserId = JSON.parse(res.body).id;
+  });
+
+  it("7. admin can promote user -> editor (200)", async () => {
+    const res = await testApp.app.inject({
+      method: "PUT",
+      url: `/api/auth/users/${targetUserId}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { role: "editor" },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).ok).toBe(true);
+  });
+
+  it("8. admin can promote user -> admin (200)", async () => {
+    // Reset target to user first
+    await testApp.app.inject({
+      method: "PUT",
+      url: `/api/auth/users/${targetUserId}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { role: "user" },
+    });
+
+    const res = await testApp.app.inject({
+      method: "PUT",
+      url: `/api/auth/users/${targetUserId}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { role: "admin" },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).ok).toBe(true);
+  });
+
+  it("9. admin can demote editor -> user (200)", async () => {
+    // Set target to editor
+    await testApp.app.inject({
+      method: "PUT",
+      url: `/api/auth/users/${targetUserId}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { role: "editor" },
+    });
+
+    const res = await testApp.app.inject({
+      method: "PUT",
+      url: `/api/auth/users/${targetUserId}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { role: "user" },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).ok).toBe(true);
+  });
+
+  it("10. admin cannot self-demote (400 SELF_DEMOTE)", async () => {
+    const sessionRes = await testApp.app.inject({
+      method: "GET",
+      url: "/api/auth/session",
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    const adminId = JSON.parse(sessionRes.body).user.id;
+
+    const res = await testApp.app.inject({
+      method: "PUT",
+      url: `/api/auth/users/${adminId}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { role: "user" },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).code).toBe("SELF_DEMOTE");
+  });
+
+  it("11. last admin cannot be demoted (400 LAST_ADMIN)", async () => {
+    // To test the LAST_ADMIN guard we need: actor is admin, target is a
+    // different admin, and target is the sole admin.  The actor being admin
+    // means adminCount >= 2, so the guard normally won't fire through the
+    // API.  We use DB manipulation to demote all other admins except the
+    // target, keeping the actor's session alive (middleware reads role from
+    // the users table at request time, so we temporarily set the actor back
+    // to admin just for the request by doing the role swap around the call).
+    //
+    // Simpler approach: demote every admin except the original to non-admin
+    // via DB, then verify self-demote blocks the last admin.  SELF_DEMOTE
+    // fires first in the code, which is correct — both guards protect the
+    // last admin.
+
+    const sessionRes = await testApp.app.inject({
+      method: "GET",
+      url: "/api/auth/session",
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    const originalAdminId = JSON.parse(sessionRes.body).user.id;
+
+    // Demote ALL admins except the original via DB
+    const allUsers = db.select().from(schema.users).all();
+    for (const u of allUsers) {
+      if (u.role === "admin" && u.id !== originalAdminId) {
+        db.update(schema.users).set({ role: "user" }).where(eq(schema.users.id, u.id)).run();
+      }
+    }
+
+    // Confirm only 1 admin exists
+    const usersRes = await testApp.app.inject({
+      method: "GET",
+      url: "/api/auth/users",
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    const admins = JSON.parse(usersRes.body).users.filter(
+      (u: { role: string }) => u.role === "admin",
+    );
+    expect(admins.length).toBe(1);
+
+    // Attempt to demote the sole admin (self-demote fires first, which is
+    // the correct behavior — the last admin is protected)
+    const res = await testApp.app.inject({
+      method: "PUT",
+      url: `/api/auth/users/${originalAdminId}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { role: "user" },
+    });
+    expect(res.statusCode).toBe(400);
+    // SELF_DEMOTE fires before LAST_ADMIN because the code checks id === admin.id first
+    expect(["SELF_DEMOTE", "LAST_ADMIN"]).toContain(JSON.parse(res.body).code);
+  });
+
+  it("12. admin can demote another admin when 2+ admins exist (200)", async () => {
+    const res2 = await registerUser(adminToken, `adm2_${ts}_12`, "admin");
+    const admin2Id = JSON.parse(res2.body).id;
+
+    const res = await testApp.app.inject({
+      method: "PUT",
+      url: `/api/auth/users/${admin2Id}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { role: "user" },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).ok).toBe(true);
+  });
+});
+
+// ── Self-delete prevention ────────────────────────────────────────
+
+describe("self-delete prevention", () => {
+  it("13. admin cannot delete themselves (400 SELF_DELETE)", async () => {
+    const sessionRes = await testApp.app.inject({
+      method: "GET",
+      url: "/api/auth/session",
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    const adminId = JSON.parse(sessionRes.body).user.id;
+
+    const res = await testApp.app.inject({
+      method: "DELETE",
+      url: `/api/auth/users/${adminId}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).code).toBe("SELF_DELETE");
+  });
+});

--- a/tests/integration/ownership-enforcement.test.ts
+++ b/tests/integration/ownership-enforcement.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Cross-user ownership enforcement tests.
+ *
+ * Validates that files and pipelines are properly scoped per-user,
+ * that editors (files:all, pipelines:all) can see everything,
+ * and that API key scoping respects ownership boundaries.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { eq } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { db, schema } from "../../apps/api/src/db/index.js";
+import { buildTestApp, createMultipartPayload, loginAsAdmin, type TestApp } from "./test-server.js";
+
+let testApp: TestApp;
+let adminToken: string;
+
+// Unique suffix to avoid collisions with other test files sharing the DB
+const ts = Date.now();
+const userAName = `own_userA_${ts}`;
+const userBName = `own_userB_${ts}`;
+const editorName = `own_editor_${ts}`;
+
+let userAToken: string;
+let userBToken: string;
+let editorToken: string;
+
+// Shared state across tests
+let userAFileId: string;
+let userAPipelineId: string;
+
+// Load test fixture
+const fixtureBuffer = readFileSync(join(import.meta.dirname, "..", "fixtures", "test-1x1.png"));
+
+/** Register a user, clear mustChangePassword, log in, return token. */
+async function createAndLogin(
+  app: TestApp["app"],
+  token: string,
+  username: string,
+  role: "user" | "editor" | "admin",
+): Promise<string> {
+  await app.inject({
+    method: "POST",
+    url: "/api/auth/register",
+    headers: { authorization: `Bearer ${token}` },
+    payload: { username, password: "TestPass1", role },
+  });
+  db.update(schema.users)
+    .set({ mustChangePassword: false })
+    .where(eq(schema.users.username, username))
+    .run();
+  const loginRes = await app.inject({
+    method: "POST",
+    url: "/api/auth/login",
+    payload: { username, password: "TestPass1" },
+  });
+  const body = JSON.parse(loginRes.body);
+  if (!body.token) throw new Error(`Login failed for ${username}: ${loginRes.body}`);
+  return body.token as string;
+}
+
+beforeAll(async () => {
+  testApp = await buildTestApp();
+  adminToken = await loginAsAdmin(testApp.app);
+
+  // Create three actors: userA (user), userB (user), editor
+  userAToken = await createAndLogin(testApp.app, adminToken, userAName, "user");
+  userBToken = await createAndLogin(testApp.app, adminToken, userBName, "user");
+  editorToken = await createAndLogin(testApp.app, adminToken, editorName, "editor");
+}, 30_000);
+
+afterAll(async () => {
+  await testApp.cleanup();
+}, 10_000);
+
+// ── File ownership ────────────────────────────────────────────────────
+
+describe("file ownership enforcement", () => {
+  it("1. user A uploads a file -> 201", async () => {
+    const { body, contentType } = createMultipartPayload([
+      {
+        name: "file",
+        filename: "userA-image.png",
+        contentType: "image/png",
+        content: fixtureBuffer,
+      },
+    ]);
+
+    const res = await testApp.app.inject({
+      method: "POST",
+      url: "/api/v1/files/upload",
+      headers: {
+        "content-type": contentType,
+        authorization: `Bearer ${userAToken}`,
+      },
+      body,
+    });
+
+    expect(res.statusCode).toBe(201);
+    const parsed = JSON.parse(res.body);
+    expect(parsed.files).toHaveLength(1);
+    userAFileId = parsed.files[0].id;
+  });
+
+  it("2. user A can access their own file -> 200", async () => {
+    const res = await testApp.app.inject({
+      method: "GET",
+      url: `/api/v1/files/${userAFileId}`,
+      headers: { authorization: `Bearer ${userAToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const parsed = JSON.parse(res.body);
+    expect(parsed.file.id).toBe(userAFileId);
+  });
+
+  it("3. user B cannot access user A's file -> 404", async () => {
+    const res = await testApp.app.inject({
+      method: "GET",
+      url: `/api/v1/files/${userAFileId}`,
+      headers: { authorization: `Bearer ${userBToken}` },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("4. editor can access user A's file (has files:all) -> 200", async () => {
+    const res = await testApp.app.inject({
+      method: "GET",
+      url: `/api/v1/files/${userAFileId}`,
+      headers: { authorization: `Bearer ${editorToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const parsed = JSON.parse(res.body);
+    expect(parsed.file.id).toBe(userAFileId);
+  });
+
+  it("5. admin can access user A's file -> 200", async () => {
+    const res = await testApp.app.inject({
+      method: "GET",
+      url: `/api/v1/files/${userAFileId}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const parsed = JSON.parse(res.body);
+    expect(parsed.file.id).toBe(userAFileId);
+  });
+
+  it("6. user B's file list does NOT contain user A's files", async () => {
+    const res = await testApp.app.inject({
+      method: "GET",
+      url: "/api/v1/files",
+      headers: { authorization: `Bearer ${userBToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const parsed = JSON.parse(res.body);
+    const ids = parsed.files.map((f: { id: string }) => f.id);
+    expect(ids).not.toContain(userAFileId);
+  });
+
+  it("7. editor's file list DOES contain user A's files", async () => {
+    const res = await testApp.app.inject({
+      method: "GET",
+      url: "/api/v1/files",
+      headers: { authorization: `Bearer ${editorToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const parsed = JSON.parse(res.body);
+    const ids = parsed.files.map((f: { id: string }) => f.id);
+    expect(ids).toContain(userAFileId);
+  });
+
+  it("8. user B cannot download user A's file -> 404", async () => {
+    const res = await testApp.app.inject({
+      method: "GET",
+      url: `/api/v1/files/${userAFileId}/download`,
+      headers: { authorization: `Bearer ${userBToken}` },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+// ── Pipeline ownership ────────────────────────────────────────────────
+
+describe("pipeline ownership enforcement", () => {
+  it("9. user A saves a pipeline -> 201", async () => {
+    const res = await testApp.app.inject({
+      method: "POST",
+      url: "/api/v1/pipeline/save",
+      headers: { authorization: `Bearer ${userAToken}` },
+      payload: {
+        name: `Pipeline-A-${ts}`,
+        steps: [{ toolId: "rotate", settings: { angle: 90 } }],
+      },
+    });
+    expect(res.statusCode).toBe(201);
+    const parsed = JSON.parse(res.body);
+    userAPipelineId = parsed.id;
+  });
+
+  it("10. user B's pipeline list does NOT include user A's pipeline", async () => {
+    const res = await testApp.app.inject({
+      method: "GET",
+      url: "/api/v1/pipeline/list",
+      headers: { authorization: `Bearer ${userBToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const parsed = JSON.parse(res.body);
+    const ids = parsed.pipelines.map((p: { id: string }) => p.id);
+    expect(ids).not.toContain(userAPipelineId);
+  });
+
+  it("11. editor CAN see user A's pipeline (has pipelines:all)", async () => {
+    const res = await testApp.app.inject({
+      method: "GET",
+      url: "/api/v1/pipeline/list",
+      headers: { authorization: `Bearer ${editorToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const parsed = JSON.parse(res.body);
+    const ids = parsed.pipelines.map((p: { id: string }) => p.id);
+    expect(ids).toContain(userAPipelineId);
+  });
+
+  it("12. user B cannot delete user A's pipeline -> 403", async () => {
+    const res = await testApp.app.inject({
+      method: "DELETE",
+      url: `/api/v1/pipeline/${userAPipelineId}`,
+      headers: { authorization: `Bearer ${userBToken}` },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("13. editor can delete user A's pipeline (has pipelines:all) -> 200", async () => {
+    // Save a second pipeline for user A so test 13 doesn't conflict with later tests
+    const saveRes = await testApp.app.inject({
+      method: "POST",
+      url: "/api/v1/pipeline/save",
+      headers: { authorization: `Bearer ${userAToken}` },
+      payload: {
+        name: `Pipeline-A-Deletable-${ts}`,
+        steps: [{ toolId: "rotate", settings: { angle: 180 } }],
+      },
+    });
+    const deletableId = JSON.parse(saveRes.body).id;
+
+    const res = await testApp.app.inject({
+      method: "DELETE",
+      url: `/api/v1/pipeline/${deletableId}`,
+      headers: { authorization: `Bearer ${editorToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const parsed = JSON.parse(res.body);
+    expect(parsed.ok).toBe(true);
+  });
+
+  it("14. delete non-existent pipeline -> 404", async () => {
+    const res = await testApp.app.inject({
+      method: "DELETE",
+      url: "/api/v1/pipeline/00000000-0000-0000-0000-000000000000",
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+// ── API key scoped ownership ──────────────────────────────────────────
+
+describe("API key scoped ownership", () => {
+  it("15. admin scoped key without files:all behaves like restricted user for file listing", async () => {
+    // Create an API key for admin that only has files:own (not files:all)
+    const createRes = await testApp.app.inject({
+      method: "POST",
+      url: "/api/v1/api-keys",
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: {
+        name: `scoped-no-files-all-${ts}`,
+        permissions: ["tools:use", "files:own", "settings:read"],
+      },
+    });
+    expect(createRes.statusCode).toBe(201);
+    const apiKey = JSON.parse(createRes.body).key;
+
+    // List files using the scoped key -- should NOT see user A's files
+    // because the key only has files:own, scoping to the admin's own files
+    const listRes = await testApp.app.inject({
+      method: "GET",
+      url: "/api/v1/files",
+      headers: { authorization: `Bearer ${apiKey}` },
+    });
+    expect(listRes.statusCode).toBe(200);
+    const parsed = JSON.parse(listRes.body);
+    const ids = parsed.files.map((f: { id: string }) => f.id);
+    // user A's file should not appear because the scoped key lacks files:all
+    expect(ids).not.toContain(userAFileId);
+  });
+});

--- a/tests/integration/permissions.test.ts
+++ b/tests/integration/permissions.test.ts
@@ -515,6 +515,88 @@ describe("file ownership scoping", () => {
   });
 });
 
+describe("escalation prevention", () => {
+  it("editor cannot create admin users", async () => {
+    // First create an editor
+    await testApp.app.inject({
+      method: "POST",
+      url: "/api/auth/register",
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { username: "esceditor", password: "EscEditor1", role: "editor" },
+    });
+    db.update(schema.users)
+      .set({ mustChangePassword: false })
+      .where(eq(schema.users.username, "esceditor"))
+      .run();
+
+    const editorLogin = await testApp.app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      payload: { username: "esceditor", password: "EscEditor1" },
+    });
+    const editorToken = JSON.parse(editorLogin.body).token;
+
+    const res = await testApp.app.inject({
+      method: "POST",
+      url: "/api/auth/register",
+      headers: { authorization: `Bearer ${editorToken}` },
+      payload: { username: "escalated", password: "Escalated1", role: "admin" },
+    });
+    // Editor doesn't have users:manage, so gets 403
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("cannot demote the last admin", async () => {
+    const listRes = await testApp.app.inject({
+      method: "GET",
+      url: "/api/auth/users",
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    const users = JSON.parse(listRes.body).users;
+    const adminUser = users.find((u: any) => u.username === "admin");
+
+    const res = await testApp.app.inject({
+      method: "PUT",
+      url: `/api/auth/users/${adminUser.id}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { role: "user" },
+    });
+    expect(res.statusCode).toBe(400);
+    const body = JSON.parse(res.body);
+    expect(body.code).toMatch(/SELF_DEMOTE|LAST_ADMIN/);
+  });
+
+  it("admin can demote another admin when multiple admins exist", async () => {
+    // Create a second admin
+    await testApp.app.inject({
+      method: "POST",
+      url: "/api/auth/register",
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { username: "admin2esc", password: "Admin2Esc1", role: "admin" },
+    });
+    db.update(schema.users)
+      .set({ mustChangePassword: false })
+      .where(eq(schema.users.username, "admin2esc"))
+      .run();
+
+    const listRes = await testApp.app.inject({
+      method: "GET",
+      url: "/api/auth/users",
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    const users = JSON.parse(listRes.body).users;
+    const secondAdmin = users.find((u: any) => u.username === "admin2esc");
+
+    const res = await testApp.app.inject({
+      method: "PUT",
+      url: `/api/auth/users/${secondAdmin.id}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { role: "editor" },
+    });
+    expect(res.statusCode).toBe(200);
+  });
+});
+
 describe("pipeline ownership scoping", () => {
   let userToken: string;
 

--- a/tests/integration/rbac-matrix-full.test.ts
+++ b/tests/integration/rbac-matrix-full.test.ts
@@ -1,0 +1,398 @@
+/**
+ * Comprehensive RBAC route permission matrix.
+ *
+ * Tests every route × every role (admin, editor, user, unauthenticated)
+ * to verify the correct HTTP status code is returned. Also validates
+ * cross-role session isolation and token edge cases.
+ */
+import { eq } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { db, schema } from "../../apps/api/src/db/index.js";
+import { buildTestApp, loginAsAdmin, type TestApp } from "./test-server.js";
+
+let testApp: TestApp;
+let adminToken: string;
+let editorToken: string;
+let userToken: string;
+
+const runId = Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
+
+beforeAll(async () => {
+  testApp = await buildTestApp();
+  adminToken = await loginAsAdmin(testApp.app);
+
+  // Create editor
+  const editorUsername = `full_editor_${runId}`;
+  await testApp.app.inject({
+    method: "POST",
+    url: "/api/auth/register",
+    headers: { authorization: `Bearer ${adminToken}` },
+    payload: { username: editorUsername, password: "EditorPass1", role: "editor" },
+  });
+  db.update(schema.users)
+    .set({ mustChangePassword: false })
+    .where(eq(schema.users.username, editorUsername))
+    .run();
+  const editorLogin = await testApp.app.inject({
+    method: "POST",
+    url: "/api/auth/login",
+    payload: { username: editorUsername, password: "EditorPass1" },
+  });
+  editorToken = JSON.parse(editorLogin.body).token;
+
+  // Create user
+  const userUsername = `full_user_${runId}`;
+  await testApp.app.inject({
+    method: "POST",
+    url: "/api/auth/register",
+    headers: { authorization: `Bearer ${adminToken}` },
+    payload: { username: userUsername, password: "UserPass12", role: "user" },
+  });
+  db.update(schema.users)
+    .set({ mustChangePassword: false })
+    .where(eq(schema.users.username, userUsername))
+    .run();
+  const userLogin = await testApp.app.inject({
+    method: "POST",
+    url: "/api/auth/login",
+    payload: { username: userUsername, password: "UserPass12" },
+  });
+  userToken = JSON.parse(userLogin.body).token;
+}, 30_000);
+
+afterAll(async () => {
+  await testApp.cleanup();
+}, 10_000);
+
+// ---------------------------------------------------------------------------
+// Route permission matrix
+// ---------------------------------------------------------------------------
+
+interface RouteTest {
+  method: "GET" | "POST" | "PUT" | "DELETE";
+  url: string;
+  payload?: unknown | (() => unknown);
+  admin: number;
+  editor: number;
+  user: number;
+  unauth: number;
+  label?: string;
+}
+
+const routes: RouteTest[] = [
+  // --- Public routes (no auth required) ---
+  {
+    method: "GET",
+    url: "/api/v1/health",
+    admin: 200,
+    editor: 200,
+    user: 200,
+    unauth: 200,
+    label: "public health check",
+  },
+  {
+    method: "GET",
+    url: "/api/v1/config/auth",
+    admin: 200,
+    editor: 200,
+    user: 200,
+    unauth: 200,
+    label: "public auth config",
+  },
+
+  // --- Auth-only routes (any authenticated user) ---
+  {
+    method: "GET",
+    url: "/api/v1/settings",
+    admin: 200,
+    editor: 200,
+    user: 200,
+    unauth: 401,
+    label: "settings:read",
+  },
+  {
+    method: "GET",
+    url: "/api/v1/files",
+    admin: 200,
+    editor: 200,
+    user: 200,
+    unauth: 401,
+    label: "requireAuth",
+  },
+  {
+    method: "GET",
+    url: "/api/v1/pipeline/list",
+    admin: 200,
+    editor: 200,
+    user: 200,
+    unauth: 401,
+    label: "requireAuth",
+  },
+  {
+    method: "GET",
+    url: "/api/v1/api-keys",
+    admin: 200,
+    editor: 200,
+    user: 200,
+    unauth: 401,
+    label: "requireAuth",
+  },
+  {
+    method: "POST",
+    url: "/api/v1/api-keys",
+    payload: { name: `test-key-${runId}` },
+    admin: 201,
+    editor: 201,
+    user: 201,
+    unauth: 401,
+    label: "requireAuth (create api key)",
+  },
+
+  // --- Admin-only routes ---
+  {
+    method: "PUT",
+    url: "/api/v1/settings",
+    payload: { _test: "v" },
+    admin: 200,
+    editor: 403,
+    user: 403,
+    unauth: 401,
+    label: "settings:write",
+  },
+  {
+    method: "GET",
+    url: "/api/auth/users",
+    admin: 200,
+    editor: 403,
+    user: 403,
+    unauth: 401,
+    label: "users:manage",
+  },
+  {
+    method: "POST",
+    url: "/api/auth/register",
+    payload: () => ({
+      username: `reg_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`,
+      password: "TempPass1",
+      role: "user",
+    }),
+    admin: 201,
+    editor: 403,
+    user: 403,
+    unauth: 401,
+    label: "users:manage (register)",
+  },
+  {
+    method: "GET",
+    url: "/api/v1/teams",
+    admin: 200,
+    editor: 403,
+    user: 403,
+    unauth: 401,
+    label: "teams:manage",
+  },
+  {
+    method: "POST",
+    url: "/api/v1/teams",
+    payload: () => ({
+      name: `team_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`,
+    }),
+    admin: 201,
+    editor: 403,
+    user: 403,
+    unauth: 401,
+    label: "teams:manage (create)",
+  },
+  {
+    method: "GET",
+    url: "/api/v1/roles",
+    admin: 200,
+    editor: 403,
+    user: 403,
+    unauth: 401,
+    label: "audit:read (roles list)",
+  },
+  {
+    method: "POST",
+    url: "/api/v1/roles",
+    payload: () => ({
+      name: `role_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`,
+      permissions: ["tools:use", "files:own"],
+    }),
+    admin: 201,
+    editor: 403,
+    user: 403,
+    unauth: 401,
+    label: "users:manage (create role)",
+  },
+  {
+    method: "GET",
+    url: "/api/v1/audit-log",
+    admin: 200,
+    editor: 403,
+    user: 403,
+    unauth: 401,
+    label: "audit:read",
+  },
+  {
+    method: "GET",
+    url: "/api/v1/admin/health",
+    admin: 200,
+    editor: 403,
+    user: 403,
+    unauth: 401,
+    label: "system:health",
+  },
+  {
+    method: "DELETE",
+    url: "/api/v1/settings/logo",
+    admin: 200,
+    editor: 403,
+    user: 403,
+    unauth: 401,
+    label: "branding:manage (delete logo)",
+  },
+];
+
+describe("RBAC route permission matrix (full)", () => {
+  for (const route of routes) {
+    for (const [role, expectedStatus] of Object.entries({
+      admin: route.admin,
+      editor: route.editor,
+      user: route.user,
+      unauth: route.unauth,
+    })) {
+      const suffix = route.label ? ` [${route.label}]` : "";
+      it(`${route.method} ${route.url} -> ${role} = ${expectedStatus}${suffix}`, async () => {
+        const headers: Record<string, string> = {};
+        const token =
+          role === "admin"
+            ? adminToken
+            : role === "editor"
+              ? editorToken
+              : role === "user"
+                ? userToken
+                : undefined;
+        if (token) {
+          headers.authorization = `Bearer ${token}`;
+        }
+
+        const payload = typeof route.payload === "function" ? route.payload() : route.payload;
+
+        const res = await testApp.app.inject({
+          method: route.method,
+          url: route.url,
+          headers,
+          ...(payload ? { payload } : {}),
+        });
+        expect(res.statusCode).toBe(expectedStatus);
+      });
+    }
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Cross-role isolation
+// ---------------------------------------------------------------------------
+
+describe("Cross-role isolation", () => {
+  it("editor session returns correct role and permissions", async () => {
+    const res = await testApp.app.inject({
+      method: "GET",
+      url: "/api/auth/session",
+      headers: { authorization: `Bearer ${editorToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.user.role).toBe("editor");
+    expect(body.user.permissions).toEqual(
+      expect.arrayContaining([
+        "tools:use",
+        "files:own",
+        "files:all",
+        "apikeys:own",
+        "pipelines:own",
+        "pipelines:all",
+        "settings:read",
+      ]),
+    );
+    // Must NOT have admin-only permissions
+    expect(body.user.permissions).not.toContain("settings:write");
+    expect(body.user.permissions).not.toContain("users:manage");
+    expect(body.user.permissions).not.toContain("teams:manage");
+    expect(body.user.permissions).not.toContain("branding:manage");
+    expect(body.user.permissions).not.toContain("features:manage");
+    expect(body.user.permissions).not.toContain("system:health");
+    expect(body.user.permissions).not.toContain("audit:read");
+  });
+
+  it("user session returns correct role and permissions", async () => {
+    const res = await testApp.app.inject({
+      method: "GET",
+      url: "/api/auth/session",
+      headers: { authorization: `Bearer ${userToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.user.role).toBe("user");
+    expect(body.user.permissions).toEqual(
+      expect.arrayContaining([
+        "tools:use",
+        "files:own",
+        "apikeys:own",
+        "pipelines:own",
+        "settings:read",
+      ]),
+    );
+    // Must NOT have editor or admin permissions
+    expect(body.user.permissions).not.toContain("files:all");
+    expect(body.user.permissions).not.toContain("pipelines:all");
+    expect(body.user.permissions).not.toContain("settings:write");
+    expect(body.user.permissions).not.toContain("users:manage");
+    expect(body.user.permissions).not.toContain("teams:manage");
+  });
+
+  it("invalid token returns 401", async () => {
+    const res = await testApp.app.inject({
+      method: "GET",
+      url: "/api/auth/session",
+      headers: { authorization: "Bearer totally-bogus-token-value" },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("expired session returns 401", async () => {
+    // Create a session, then manually expire it in the DB
+    const expiredUsername = `expired_${runId}`;
+    await testApp.app.inject({
+      method: "POST",
+      url: "/api/auth/register",
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { username: expiredUsername, password: "ExpiredPass1", role: "user" },
+    });
+    db.update(schema.users)
+      .set({ mustChangePassword: false })
+      .where(eq(schema.users.username, expiredUsername))
+      .run();
+
+    const loginRes = await testApp.app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      payload: { username: expiredUsername, password: "ExpiredPass1" },
+    });
+    const expiredToken = JSON.parse(loginRes.body).token;
+
+    // Manually expire the session
+    db.update(schema.sessions)
+      .set({ expiresAt: new Date(Date.now() - 60_000) })
+      .where(eq(schema.sessions.id, expiredToken))
+      .run();
+
+    const res = await testApp.app.inject({
+      method: "GET",
+      url: "/api/auth/session",
+      headers: { authorization: `Bearer ${expiredToken}` },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+});

--- a/tests/integration/rbac-matrix.test.ts
+++ b/tests/integration/rbac-matrix.test.ts
@@ -1,0 +1,136 @@
+import { eq } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { db, schema } from "../../apps/api/src/db/index.js";
+import { buildTestApp, loginAsAdmin, type TestApp } from "./test-server.js";
+
+let testApp: TestApp;
+let adminToken: string;
+let editorToken: string;
+let userToken: string;
+
+beforeAll(async () => {
+  testApp = await buildTestApp();
+  adminToken = await loginAsAdmin(testApp.app);
+
+  // Create editor
+  await testApp.app.inject({
+    method: "POST",
+    url: "/api/auth/register",
+    headers: { authorization: `Bearer ${adminToken}` },
+    payload: { username: "matrix_editor", password: "EditorPass1", role: "editor" },
+  });
+  db.update(schema.users)
+    .set({ mustChangePassword: false })
+    .where(eq(schema.users.username, "matrix_editor"))
+    .run();
+  const editorLogin = await testApp.app.inject({
+    method: "POST",
+    url: "/api/auth/login",
+    payload: { username: "matrix_editor", password: "EditorPass1" },
+  });
+  editorToken = JSON.parse(editorLogin.body).token;
+
+  // Create user
+  await testApp.app.inject({
+    method: "POST",
+    url: "/api/auth/register",
+    headers: { authorization: `Bearer ${adminToken}` },
+    payload: { username: "matrix_user", password: "UserPass12", role: "user" },
+  });
+  db.update(schema.users)
+    .set({ mustChangePassword: false })
+    .where(eq(schema.users.username, "matrix_user"))
+    .run();
+  const userLogin = await testApp.app.inject({
+    method: "POST",
+    url: "/api/auth/login",
+    payload: { username: "matrix_user", password: "UserPass12" },
+  });
+  userToken = JSON.parse(userLogin.body).token;
+}, 30_000);
+
+afterAll(async () => {
+  await testApp.cleanup();
+}, 10_000);
+
+interface RouteTest {
+  method: "GET" | "POST" | "PUT" | "DELETE";
+  url: string;
+  payload?: unknown;
+  admin: number;
+  editor: number;
+  user: number;
+  unauth: number;
+}
+
+const routes: RouteTest[] = [
+  // Settings
+  { method: "GET", url: "/api/v1/settings", admin: 200, editor: 200, user: 200, unauth: 401 },
+  {
+    method: "PUT",
+    url: "/api/v1/settings",
+    payload: { _test: "v" },
+    admin: 200,
+    editor: 403,
+    user: 403,
+    unauth: 401,
+  },
+
+  // Users management
+  { method: "GET", url: "/api/auth/users", admin: 200, editor: 403, user: 403, unauth: 401 },
+
+  // Teams
+  { method: "GET", url: "/api/v1/teams", admin: 200, editor: 403, user: 403, unauth: 401 },
+
+  // Audit log
+  { method: "GET", url: "/api/v1/audit-log", admin: 200, editor: 403, user: 403, unauth: 401 },
+
+  // Admin health
+  { method: "GET", url: "/api/v1/admin/health", admin: 200, editor: 403, user: 403, unauth: 401 },
+
+  // Files
+  { method: "GET", url: "/api/v1/files", admin: 200, editor: 200, user: 200, unauth: 401 },
+
+  // Pipelines
+  { method: "GET", url: "/api/v1/pipeline/list", admin: 200, editor: 200, user: 200, unauth: 401 },
+
+  // API keys
+  { method: "GET", url: "/api/v1/api-keys", admin: 200, editor: 200, user: 200, unauth: 401 },
+
+  // Health (public)
+  { method: "GET", url: "/api/v1/health", admin: 200, editor: 200, user: 200, unauth: 200 },
+];
+
+describe("RBAC permission matrix", () => {
+  for (const route of routes) {
+    for (const [role, expectedStatus] of Object.entries({
+      admin: route.admin,
+      editor: route.editor,
+      user: route.user,
+      unauth: route.unauth,
+    })) {
+      it(`${route.method} ${route.url} → ${role} = ${expectedStatus}`, async () => {
+        const headers: Record<string, string> = {};
+        const token =
+          role === "admin"
+            ? adminToken
+            : role === "editor"
+              ? editorToken
+              : role === "user"
+                ? userToken
+                : undefined;
+        if (token) {
+          headers.authorization = `Bearer ${token}`;
+        }
+
+        const res = await testApp.app.inject({
+          method: route.method,
+          url: route.url,
+          headers,
+          ...(route.payload ? { payload: route.payload } : {}),
+        });
+        expect(res.statusCode).toBe(expectedStatus);
+      });
+    }
+  }
+});

--- a/tests/integration/test-server.ts
+++ b/tests/integration/test-server.ts
@@ -40,6 +40,7 @@ import { docsRoutes } from "../../apps/api/src/routes/docs.js";
 import { fileRoutes } from "../../apps/api/src/routes/files.js";
 import { registerPipelineRoutes } from "../../apps/api/src/routes/pipeline.js";
 import { registerProgressRoutes } from "../../apps/api/src/routes/progress.js";
+import { rolesRoutes } from "../../apps/api/src/routes/roles.js";
 import { settingsRoutes } from "../../apps/api/src/routes/settings.js";
 import { teamsRoutes } from "../../apps/api/src/routes/teams.js";
 import { registerToolRoutes } from "../../apps/api/src/routes/tools/index.js";
@@ -115,6 +116,9 @@ export async function buildTestApp(): Promise<TestApp> {
 
   // Audit log routes
   await auditLogRoutes(app);
+
+  // Roles management routes
+  await rolesRoutes(app);
 
   // API docs (Scalar)
   await docsRoutes(app);

--- a/tests/integration/test-server.ts
+++ b/tests/integration/test-server.ts
@@ -29,12 +29,8 @@ import Fastify from "fastify";
 import { env } from "../../apps/api/src/config.js";
 import { db, schema } from "../../apps/api/src/db/index.js";
 import { runMigrations } from "../../apps/api/src/db/migrate.js";
-import {
-  authMiddleware,
-  authRoutes,
-  ensureDefaultAdmin,
-  requireAdmin,
-} from "../../apps/api/src/plugins/auth.js";
+import { requirePermission } from "../../apps/api/src/permissions.js";
+import { authMiddleware, authRoutes, ensureDefaultAdmin } from "../../apps/api/src/plugins/auth.js";
 import { registerUpload } from "../../apps/api/src/plugins/upload.js";
 import { apiKeyRoutes } from "../../apps/api/src/routes/api-keys.js";
 import { registerBatchRoutes } from "../../apps/api/src/routes/batch.js";
@@ -127,7 +123,7 @@ export async function buildTestApp(): Promise<TestApp> {
 
   // Admin health check (full diagnostics)
   app.get("/api/v1/admin/health", async (request, reply) => {
-    const admin = requireAdmin(request, reply);
+    const admin = requirePermission("system:health")(request, reply);
     if (!admin) return;
 
     let dbOk = false;

--- a/tests/integration/test-server.ts
+++ b/tests/integration/test-server.ts
@@ -33,6 +33,7 @@ import { requirePermission } from "../../apps/api/src/permissions.js";
 import { authMiddleware, authRoutes, ensureDefaultAdmin } from "../../apps/api/src/plugins/auth.js";
 import { registerUpload } from "../../apps/api/src/plugins/upload.js";
 import { apiKeyRoutes } from "../../apps/api/src/routes/api-keys.js";
+import { auditLogRoutes } from "../../apps/api/src/routes/audit-log.js";
 import { registerBatchRoutes } from "../../apps/api/src/routes/batch.js";
 import { brandingRoutes } from "../../apps/api/src/routes/branding.js";
 import { docsRoutes } from "../../apps/api/src/routes/docs.js";
@@ -111,6 +112,9 @@ export async function buildTestApp(): Promise<TestApp> {
 
   // Teams routes
   await teamsRoutes(app);
+
+  // Audit log routes
+  await auditLogRoutes(app);
 
   // API docs (Scalar)
   await docsRoutes(app);

--- a/tests/unit/api/audit-helpers.test.ts
+++ b/tests/unit/api/audit-helpers.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Unit tests for audit event mapping and actor extraction logic.
+ *
+ * Since deriveTargetType is not exported from audit.ts, we reproduce the
+ * mapping logic here so we can verify every event type maps correctly.
+ * Actor ID and username extraction logic is tested via the same rules
+ * used in auditLog().
+ */
+
+import { describe, expect, it } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Reproduce the private deriveTargetType logic so we can test its mapping
+// ---------------------------------------------------------------------------
+type AuditEvent =
+  | "LOGIN_SUCCESS"
+  | "LOGIN_FAILED"
+  | "LOGOUT"
+  | "PASSWORD_CHANGED"
+  | "PASSWORD_RESET"
+  | "USER_CREATED"
+  | "USER_DELETED"
+  | "USER_UPDATED"
+  | "FILE_UPLOADED"
+  | "FILE_DELETED"
+  | "API_KEY_CREATED"
+  | "API_KEY_DELETED"
+  | "ROLE_CREATED"
+  | "ROLE_UPDATED"
+  | "ROLE_DELETED"
+  | "SETTINGS_UPDATED";
+
+function deriveTargetType(event: AuditEvent): string | null {
+  if (
+    event.startsWith("USER_") ||
+    event.startsWith("LOGIN") ||
+    event.startsWith("PASSWORD") ||
+    event === "LOGOUT"
+  )
+    return "user";
+  if (event.startsWith("API_KEY")) return "api_key";
+  if (event.startsWith("FILE")) return "file";
+  if (event.startsWith("ROLE")) return "role";
+  if (event === "SETTINGS_UPDATED") return "setting";
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Reproduce the actor extraction logic from auditLog()
+// ---------------------------------------------------------------------------
+function extractActorId(details: Record<string, unknown>): string | null {
+  return (details.userId as string) ?? (details.adminId as string) ?? null;
+}
+
+function extractActorUsername(details: Record<string, unknown>): string {
+  return (
+    (details.username as string) ??
+    (details.newUsername as string) ??
+    "system"
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe("audit helpers", () => {
+  describe("deriveTargetType", () => {
+    it.each<[AuditEvent, string]>([
+      ["LOGIN_SUCCESS", "user"],
+      ["LOGIN_FAILED", "user"],
+      ["LOGOUT", "user"],
+      ["PASSWORD_CHANGED", "user"],
+      ["PASSWORD_RESET", "user"],
+      ["USER_CREATED", "user"],
+      ["USER_DELETED", "user"],
+      ["USER_UPDATED", "user"],
+    ])("%s -> %s", (event, expected) => {
+      expect(deriveTargetType(event)).toBe(expected);
+    });
+
+    it.each<[AuditEvent, string]>([
+      ["FILE_UPLOADED", "file"],
+      ["FILE_DELETED", "file"],
+    ])("%s -> %s", (event, expected) => {
+      expect(deriveTargetType(event)).toBe(expected);
+    });
+
+    it.each<[AuditEvent, string]>([
+      ["API_KEY_CREATED", "api_key"],
+      ["API_KEY_DELETED", "api_key"],
+    ])("%s -> %s", (event, expected) => {
+      expect(deriveTargetType(event)).toBe(expected);
+    });
+
+    it.each<[AuditEvent, string]>([
+      ["ROLE_CREATED", "role"],
+      ["ROLE_UPDATED", "role"],
+      ["ROLE_DELETED", "role"],
+    ])("%s -> %s", (event, expected) => {
+      expect(deriveTargetType(event)).toBe(expected);
+    });
+
+    it("SETTINGS_UPDATED -> setting", () => {
+      expect(deriveTargetType("SETTINGS_UPDATED")).toBe("setting");
+    });
+  });
+
+  describe("extractActorId", () => {
+    it("returns userId when present", () => {
+      expect(extractActorId({ userId: "u-123" })).toBe("u-123");
+    });
+
+    it("falls back to adminId when userId is absent", () => {
+      expect(extractActorId({ adminId: "a-456" })).toBe("a-456");
+    });
+
+    it("prefers userId over adminId when both are present", () => {
+      expect(extractActorId({ userId: "u-123", adminId: "a-456" })).toBe(
+        "u-123",
+      );
+    });
+
+    it("returns null when neither userId nor adminId is present", () => {
+      expect(extractActorId({})).toBeNull();
+    });
+
+    it("returns null for an empty details object", () => {
+      expect(extractActorId({})).toBeNull();
+    });
+  });
+
+  describe("extractActorUsername", () => {
+    it("returns username when present", () => {
+      expect(extractActorUsername({ username: "alice" })).toBe("alice");
+    });
+
+    it("falls back to newUsername when username is absent", () => {
+      expect(extractActorUsername({ newUsername: "bob" })).toBe("bob");
+    });
+
+    it("prefers username over newUsername when both are present", () => {
+      expect(
+        extractActorUsername({ username: "alice", newUsername: "bob" }),
+      ).toBe("alice");
+    });
+
+    it('returns "system" when neither username nor newUsername is present', () => {
+      expect(extractActorUsername({})).toBe("system");
+    });
+
+    it('returns "system" for an empty details object', () => {
+      expect(extractActorUsername({})).toBe("system");
+    });
+  });
+});

--- a/tests/unit/api/effective-permissions.test.ts
+++ b/tests/unit/api/effective-permissions.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Unit tests for effective permissions logic.
+ *
+ * Covers hasEffectivePermission (role + API key scoping),
+ * getPermissions edge cases, and hasPermission edge cases.
+ */
+
+import type { Permission, Role } from "@ashim/shared";
+import { describe, expect, it, vi } from "vitest";
+
+// Mock the auth plugin to avoid transitively opening a SQLite connection
+vi.mock("../../../apps/api/src/plugins/auth.js", () => ({
+  getAuthUser: () => null,
+}));
+
+import {
+  getPermissions,
+  hasEffectivePermission,
+  hasPermission,
+} from "../../../apps/api/src/permissions.js";
+import type { AuthUser } from "../../../apps/api/src/plugins/auth.js";
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function makeUser(overrides: Partial<AuthUser> & { role: string }): AuthUser {
+  return {
+    id: "u-1",
+    username: "testuser",
+    ...overrides,
+  };
+}
+
+// ── hasEffectivePermission ───────────────────────────────────────────
+
+describe("hasEffectivePermission", () => {
+  describe("without API key scoping (apiKeyPermissions undefined)", () => {
+    it("admin can use any permission", () => {
+      const admin = makeUser({ role: "admin" });
+      const allAdmin = getPermissions("admin");
+      for (const perm of allAdmin) {
+        expect(hasEffectivePermission(admin, perm)).toBe(true);
+      }
+    });
+
+    it("editor can use all editor permissions", () => {
+      const editor = makeUser({ role: "editor" });
+      const editorPerms = getPermissions("editor");
+      for (const perm of editorPerms) {
+        expect(hasEffectivePermission(editor, perm)).toBe(true);
+      }
+    });
+
+    it("editor cannot use admin-only permissions", () => {
+      const editor = makeUser({ role: "editor" });
+      expect(hasEffectivePermission(editor, "users:manage")).toBe(false);
+      expect(hasEffectivePermission(editor, "settings:write")).toBe(false);
+      expect(hasEffectivePermission(editor, "teams:manage")).toBe(false);
+      expect(hasEffectivePermission(editor, "branding:manage")).toBe(false);
+      expect(hasEffectivePermission(editor, "features:manage")).toBe(false);
+      expect(hasEffectivePermission(editor, "system:health")).toBe(false);
+      expect(hasEffectivePermission(editor, "audit:read")).toBe(false);
+    });
+
+    it("user can use all user permissions", () => {
+      const user = makeUser({ role: "user" });
+      const userPerms = getPermissions("user");
+      for (const perm of userPerms) {
+        expect(hasEffectivePermission(user, perm)).toBe(true);
+      }
+    });
+
+    it("user cannot use editor or admin permissions", () => {
+      const user = makeUser({ role: "user" });
+      expect(hasEffectivePermission(user, "files:all")).toBe(false);
+      expect(hasEffectivePermission(user, "pipelines:all")).toBe(false);
+      expect(hasEffectivePermission(user, "users:manage")).toBe(false);
+      expect(hasEffectivePermission(user, "settings:write")).toBe(false);
+    });
+
+    it("unknown role has no effective permissions", () => {
+      const unknown = makeUser({ role: "ghost" });
+      expect(hasEffectivePermission(unknown, "tools:use")).toBe(false);
+      expect(hasEffectivePermission(unknown, "users:manage")).toBe(false);
+    });
+  });
+
+  describe("API key scoping restricts permissions", () => {
+    it("admin scoped to tools:use can only use tools:use", () => {
+      const admin = makeUser({
+        role: "admin",
+        apiKeyPermissions: ["tools:use"],
+      });
+      expect(hasEffectivePermission(admin, "tools:use")).toBe(true);
+      expect(hasEffectivePermission(admin, "users:manage")).toBe(false);
+      expect(hasEffectivePermission(admin, "files:all")).toBe(false);
+    });
+
+    it("editor scoped to files:own and tools:use only has those", () => {
+      const editor = makeUser({
+        role: "editor",
+        apiKeyPermissions: ["files:own", "tools:use"],
+      });
+      expect(hasEffectivePermission(editor, "files:own")).toBe(true);
+      expect(hasEffectivePermission(editor, "tools:use")).toBe(true);
+      expect(hasEffectivePermission(editor, "files:all")).toBe(false);
+      expect(hasEffectivePermission(editor, "settings:read")).toBe(false);
+    });
+
+    it("user scoped to settings:read only has that", () => {
+      const user = makeUser({
+        role: "user",
+        apiKeyPermissions: ["settings:read"],
+      });
+      expect(hasEffectivePermission(user, "settings:read")).toBe(true);
+      expect(hasEffectivePermission(user, "tools:use")).toBe(false);
+      expect(hasEffectivePermission(user, "files:own")).toBe(false);
+    });
+  });
+
+  describe("API key cannot grant permissions the role lacks", () => {
+    it("user with apiKeyPermissions including users:manage still denied", () => {
+      const user = makeUser({
+        role: "user",
+        apiKeyPermissions: ["tools:use", "users:manage"],
+      });
+      expect(hasEffectivePermission(user, "users:manage")).toBe(false);
+      // But role-granted permission that is also in the key works
+      expect(hasEffectivePermission(user, "tools:use")).toBe(true);
+    });
+
+    it("editor with apiKeyPermissions including settings:write still denied", () => {
+      const editor = makeUser({
+        role: "editor",
+        apiKeyPermissions: ["settings:write", "files:all"],
+      });
+      expect(hasEffectivePermission(editor, "settings:write")).toBe(false);
+      // files:all is in editor role, so it works
+      expect(hasEffectivePermission(editor, "files:all")).toBe(true);
+    });
+
+    it("unknown role gains nothing even with full apiKeyPermissions", () => {
+      const unknown = makeUser({
+        role: "nobody",
+        apiKeyPermissions: ["tools:use", "files:own", "users:manage", "settings:write"],
+      });
+      expect(hasEffectivePermission(unknown, "tools:use")).toBe(false);
+      expect(hasEffectivePermission(unknown, "users:manage")).toBe(false);
+    });
+  });
+
+  describe("empty apiKeyPermissions blocks everything", () => {
+    it("admin with empty array has no effective permissions", () => {
+      const admin = makeUser({ role: "admin", apiKeyPermissions: [] });
+      const allAdmin = getPermissions("admin");
+      for (const perm of allAdmin) {
+        expect(hasEffectivePermission(admin, perm)).toBe(false);
+      }
+    });
+
+    it("user with empty array has no effective permissions", () => {
+      const user = makeUser({ role: "user", apiKeyPermissions: [] });
+      expect(hasEffectivePermission(user, "tools:use")).toBe(false);
+      expect(hasEffectivePermission(user, "files:own")).toBe(false);
+    });
+  });
+
+  describe("undefined apiKeyPermissions inherits all role permissions", () => {
+    it("admin without apiKeyPermissions gets full admin access", () => {
+      const admin = makeUser({ role: "admin" });
+      expect(admin.apiKeyPermissions).toBeUndefined();
+      expect(hasEffectivePermission(admin, "users:manage")).toBe(true);
+      expect(hasEffectivePermission(admin, "audit:read")).toBe(true);
+    });
+
+    it("user without apiKeyPermissions gets full user access", () => {
+      const user = makeUser({ role: "user" });
+      expect(user.apiKeyPermissions).toBeUndefined();
+      expect(hasEffectivePermission(user, "tools:use")).toBe(true);
+      expect(hasEffectivePermission(user, "pipelines:own")).toBe(true);
+    });
+  });
+});
+
+// ── getPermissions ───────────────────────────────────────────────────
+
+describe("getPermissions", () => {
+  describe("exact counts for built-in roles", () => {
+    it("admin has exactly 15 permissions", () => {
+      expect(getPermissions("admin")).toHaveLength(15);
+    });
+
+    it("editor has exactly 7 permissions", () => {
+      expect(getPermissions("editor")).toHaveLength(7);
+    });
+
+    it("user has exactly 5 permissions", () => {
+      expect(getPermissions("user")).toHaveLength(5);
+    });
+  });
+
+  describe("invalid and edge-case role names", () => {
+    it("empty string returns empty array", () => {
+      expect(getPermissions("")).toEqual([]);
+    });
+
+    it("null coerced to string returns empty array", () => {
+      expect(getPermissions(null as unknown as Role)).toEqual([]);
+    });
+
+    it("undefined coerced to string returns empty array", () => {
+      expect(getPermissions(undefined as unknown as Role)).toEqual([]);
+    });
+
+    it("case-sensitive: Admin (capitalized) returns empty array", () => {
+      expect(getPermissions("Admin" as Role)).toEqual([]);
+    });
+
+    it("case-sensitive: ADMIN (uppercase) returns empty array", () => {
+      expect(getPermissions("ADMIN" as Role)).toEqual([]);
+    });
+
+    it("case-sensitive: User (capitalized) returns empty array", () => {
+      expect(getPermissions("User" as Role)).toEqual([]);
+    });
+
+    it("whitespace-padded role name returns empty array", () => {
+      expect(getPermissions(" admin " as Role)).toEqual([]);
+    });
+  });
+
+  describe("role permission subsets", () => {
+    it("editor permissions are a subset of admin permissions", () => {
+      const adminPerms = getPermissions("admin");
+      const editorPerms = getPermissions("editor");
+      for (const perm of editorPerms) {
+        expect(adminPerms).toContain(perm);
+      }
+    });
+
+    it("user permissions are a subset of admin permissions", () => {
+      const adminPerms = getPermissions("admin");
+      const userPerms = getPermissions("user");
+      for (const perm of userPerms) {
+        expect(adminPerms).toContain(perm);
+      }
+    });
+
+    it("user permissions are a subset of editor permissions", () => {
+      const editorPerms = getPermissions("editor");
+      const userPerms = getPermissions("user");
+      for (const perm of userPerms) {
+        expect(editorPerms).toContain(perm);
+      }
+    });
+  });
+});
+
+// ── hasPermission edge cases ─────────────────────────────────────────
+
+describe("hasPermission edge cases", () => {
+  it("returns false for a non-existent permission string", () => {
+    expect(hasPermission("admin", "fake:perm" as Permission)).toBe(false);
+  });
+
+  it("returns false for an empty string permission", () => {
+    expect(hasPermission("admin", "" as Permission)).toBe(false);
+  });
+
+  it("returns false for unknown role even with valid permission", () => {
+    expect(hasPermission("visitor" as Role, "tools:use")).toBe(false);
+  });
+
+  it("returns false for both unknown role and unknown permission", () => {
+    expect(hasPermission("visitor" as Role, "x:y" as Permission)).toBe(false);
+  });
+});

--- a/tests/unit/api/permissions.test.ts
+++ b/tests/unit/api/permissions.test.ts
@@ -19,9 +19,9 @@ import { getPermissions, hasPermission } from "../../../apps/api/src/permissions
 
 describe("permissions", () => {
   describe("getPermissions", () => {
-    it("returns all 12 permissions for admin", () => {
+    it("returns all 15 permissions for admin", () => {
       const perms = getPermissions("admin");
-      expect(perms).toHaveLength(12);
+      expect(perms).toHaveLength(15);
       expect(perms).toContain("tools:use");
       expect(perms).toContain("files:own");
       expect(perms).toContain("files:all");
@@ -34,6 +34,9 @@ describe("permissions", () => {
       expect(perms).toContain("users:manage");
       expect(perms).toContain("teams:manage");
       expect(perms).toContain("branding:manage");
+      expect(perms).toContain("features:manage");
+      expect(perms).toContain("system:health");
+      expect(perms).toContain("audit:read");
     });
 
     it("returns only basic permissions for user role", () => {

--- a/tests/unit/api/rbac-enforcement.test.ts
+++ b/tests/unit/api/rbac-enforcement.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { getPermissions, hasPermission } from "../../../apps/api/src/permissions.js";
+
+describe("role permissions", () => {
+  it("admin has all 15 permissions", () => {
+    const perms = getPermissions("admin");
+    expect(perms).toContain("tools:use");
+    expect(perms).toContain("files:all");
+    expect(perms).toContain("users:manage");
+    expect(perms).toContain("features:manage");
+    expect(perms).toContain("system:health");
+    expect(perms).toContain("audit:read");
+    expect(perms.length).toBe(15);
+  });
+
+  it("editor has collaborative but not admin permissions", () => {
+    const perms = getPermissions("editor");
+    expect(perms).toContain("tools:use");
+    expect(perms).toContain("files:own");
+    expect(perms).toContain("files:all");
+    expect(perms).toContain("pipelines:all");
+    expect(perms).toContain("settings:read");
+    expect(perms).not.toContain("users:manage");
+    expect(perms).not.toContain("settings:write");
+    expect(perms).not.toContain("teams:manage");
+    expect(perms).not.toContain("features:manage");
+    expect(perms).not.toContain("system:health");
+    expect(perms).not.toContain("audit:read");
+  });
+
+  it("user has basic permissions only", () => {
+    const perms = getPermissions("user");
+    expect(perms).toContain("tools:use");
+    expect(perms).toContain("files:own");
+    expect(perms).toContain("apikeys:own");
+    expect(perms).toContain("pipelines:own");
+    expect(perms).toContain("settings:read");
+    expect(perms).not.toContain("files:all");
+    expect(perms).not.toContain("users:manage");
+  });
+
+  it("unknown role returns empty permissions", () => {
+    const perms = getPermissions("bogus" as any);
+    expect(perms).toEqual([]);
+  });
+
+  it("hasPermission checks correctly", () => {
+    expect(hasPermission("admin", "users:manage")).toBe(true);
+    expect(hasPermission("editor", "users:manage")).toBe(false);
+    expect(hasPermission("user", "tools:use")).toBe(true);
+    expect(hasPermission("user", "files:all")).toBe(false);
+  });
+});

--- a/tests/unit/api/username-validation.test.ts
+++ b/tests/unit/api/username-validation.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Unit tests for username validation rules.
+ *
+ * The validateUsername function is not exported from auth.ts,
+ * so we reproduce its logic here to test the rules directly.
+ */
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * Reproduce the validateUsername logic from apps/api/src/plugins/auth.ts
+ * so we can unit-test the rules without importing the module (which
+ * transitively opens a SQLite connection).
+ */
+function validateUsername(username: string): string | null {
+  if (username.length < 3 || username.length > 50) {
+    return "Username must be between 3 and 50 characters";
+  }
+  if (!/^[a-zA-Z0-9_.-]+$/.test(username)) {
+    return "Username can only contain letters, numbers, dots, hyphens, and underscores";
+  }
+  return null;
+}
+
+describe("validateUsername", () => {
+  describe("valid usernames", () => {
+    it.each([
+      ["alice", "lowercase letters"],
+      ["bob123", "letters and digits"],
+      ["user.name", "dots"],
+      ["user-name", "hyphens"],
+      ["user_name", "underscores"],
+      ["abc", "minimum length (3)"],
+      ["a".repeat(50), "maximum length (50)"],
+      ["A.B-C_D", "mixed separators and uppercase"],
+      ["123", "digits only"],
+    ])("accepts %s (%s)", (username) => {
+      expect(validateUsername(username)).toBeNull();
+    });
+  });
+
+  describe("too short", () => {
+    it.each([
+      ["ab", "2 characters"],
+      ["a", "1 character"],
+      ["", "empty string"],
+    ])("rejects %s (%s)", (username) => {
+      expect(validateUsername(username)).toBe("Username must be between 3 and 50 characters");
+    });
+  });
+
+  describe("too long", () => {
+    it("rejects a 51-character username", () => {
+      expect(validateUsername("a".repeat(51))).toBe("Username must be between 3 and 50 characters");
+    });
+  });
+
+  describe("invalid characters", () => {
+    it.each([
+      ["has space", "space"],
+      ["user@name", "@ symbol"],
+      ["user#name", "# symbol"],
+      ["user/name", "forward slash"],
+      ["<script>", "angle brackets"],
+      ["user\nname", "newline"],
+      ["user!name", "exclamation mark"],
+      ["user name", "tab character"],
+    ])("rejects '%s' (%s)", (username) => {
+      expect(validateUsername(username)).toBe(
+        "Username can only contain letters, numbers, dots, hyphens, and underscores",
+      );
+    });
+  });
+
+  describe("unicode characters", () => {
+    it.each([
+      ["élève", "accented Latin letters"],
+      ["用户名", "CJK characters"],
+      ["пользователь", "Cyrillic characters"],
+      ["üser", "umlaut"],
+    ])("rejects '%s' (%s)", (username) => {
+      expect(validateUsername(username)).toBe(
+        "Username can only contain letters, numbers, dots, hyphens, and underscores",
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Complete RBAC revamp replacing the binary admin/user authorization model with enforced, granular permission-based access control.

### Phase 1 — Core Enforcement
- **Editor role** (`editor`) added between `admin` and `user` with collaborative permissions (`files:all`, `pipelines:all`) but no admin access
- **`requirePermission()`** wired into every route — replaces all `requireAdmin()` calls with specific permission checks (`users:manage`, `settings:write`, `teams:manage`, `branding:manage`, `features:manage`, `system:health`, `audit:read`)
- **Centralized ownership checks** — ad-hoc `user.role !== "admin"` patterns replaced with `hasEffectivePermission()` calls
- **API key permission scoping** — keys can be restricted to a subset of the owner's permissions; effective permissions = role ∩ key scope
- **API key expiration** — optional `expiresAt` on key creation, enforced in auth middleware
- **Audit log** — dual-write to DB + stdout, queryable via `GET /api/v1/audit-log` with pagination and filtering
- **Escalation prevention** — users cannot create/assign roles higher than their own; last admin cannot be demoted

### Phase 2 — Advanced Features
- **Custom roles** — `roles` table with CRUD API at `/api/v1/roles`; DB-backed permission lookup; built-in roles (admin/editor/user) are immutable; deleting a custom role reassigns users to `user`
- **Roles management UI** — settings section with permission checkbox grid, built-in role protection, user count display
- **Audit log UI** — settings section with filterable table, pagination, expandable detail rows
- **API key scoping + expiration UI** — permission checkboxes and date picker in key creation form

### Test Coverage
- **1,134 total tests** (236 new) across 40 test files
- Full permission matrix: 17 routes × 4 roles (admin, editor, user, unauth)
- Cross-user ownership isolation (files, pipelines, API keys)
- Password change/reset side effects (session invalidation, key revocation)
- Escalation prevention on both register and update routes
- Custom role lifecycle (create → assign → update permissions → delete → user reassignment)
- API key scoping ceiling enforcement and immediate revocation
- Audit log event recording for all action types
- E2E tests for roles UI, audit log, custom role user tab visibility

### Database Changes
- Migration `0006`: `audit_log` table + `api_keys.permissions` column
- Migration `0007`: `roles` table with built-in role seeding
- Migration `0008`: `api_keys.expires_at` column
- `users.role` enum extended with `"editor"` (SQLite TEXT — no schema migration needed)

### Files Changed
40 files, +5,054 / -87 lines

## Test plan
- [x] All 1,134 unit + integration tests pass
- [x] TypeScript typecheck passes (5/5 packages)
- [x] Biome lint passes (0 errors, 0 warnings)
- [x] Docker image builds successfully
- [x] Full API test battery verified against Docker container
- [x] Admin: 15 permissions, full access confirmed
- [x] Editor: 7 permissions, files:all + pipelines:all but blocked from admin endpoints (403)
- [x] User: 5 permissions, own resources only
- [x] Custom role: create/assign/delete working with correct permission enforcement
- [x] API key scoping: scoped keys restricted to declared permissions
- [x] Audit log: all events recorded and queryable
- [ ] E2E Playwright tests against Docker container