### PR TITLE
fix: prevent admin escalation when AUTH_ENABLED=false

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -36,8 +36,10 @@ import { userFileRoutes } from "./routes/user-files.js";
 runMigrations();
 console.log("Database initialized");
 
-// Create default admin user if no users exist
-await ensureDefaultAdmin();
+// Create default admin user if no users exist and auth is enabled
+if (env.AUTH_ENABLED) {
+  await ensureDefaultAdmin();
+}
 
 function ensureInstanceId() {
   const existing = db

--- a/apps/api/src/plugins/auth.ts
+++ b/apps/api/src/plugins/auth.ts
@@ -160,6 +160,10 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
     "/api/auth/login",
     { config: { rateLimit: { max: getLoginAttemptLimit, timeWindow: "1 minute" } } },
     async (request: FastifyRequest, reply: FastifyReply) => {
+      if (!env.AUTH_ENABLED) {
+        return reply.status(403).send({ error: "Authentication is disabled" });
+      }
+
       const body = request.body as { username?: string; password?: string } | null;
 
       if (!body?.username || !body?.password) {
@@ -230,6 +234,22 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
 
   // GET /api/auth/session
   app.get("/api/auth/session", async (request: FastifyRequest, reply: FastifyReply) => {
+    if (!env.AUTH_ENABLED) {
+      return reply.send({
+        user: {
+          id: "anonymous",
+          username: "anonymous",
+          role: "user",
+          mustChangePassword: false,
+          permissions: getPermissions("user"),
+          analyticsEnabled: null,
+          analyticsConsentShownAt: null,
+          analyticsConsentRemindAt: null,
+        },
+        expiresAt: null,
+      });
+    }
+
     const token = extractToken(request);
     if (!token) {
       return reply.status(401).send({ error: "No session token provided" });
@@ -238,7 +258,6 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
     const session = db.select().from(schema.sessions).where(eq(schema.sessions.id, token)).get();
 
     if (!session || session.expiresAt < new Date()) {
-      // Clean up expired session if it exists
       if (session) {
         db.delete(schema.sessions).where(eq(schema.sessions.id, token)).run();
       }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -87,9 +87,7 @@ function AuthGuard({ children }: { children: React.ReactNode }) {
   const setStoreConsent = useAnalyticsStore((s) => s.setConsent);
   const location = useLocation();
 
-  // Hydrate the analytics store from session data on initial load.
-  // Only hydrate if the store is still in its initial state (user hasn't taken
-  // an explicit action like accepting/declining on the consent page).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: only hydrate on session load, not on store changes
   useEffect(() => {
     if (
       !loading &&
@@ -103,8 +101,16 @@ function AuthGuard({ children }: { children: React.ReactNode }) {
         analyticsConsentRemindAt: null,
       });
     }
-    // eslint-disable-next-line -- only hydrate on session load, not on store changes
   }, [loading, analyticsEnabled, analyticsConsentShownAt, setStoreConsent]);
+
+  // When auth is disabled, redirect away from login/change-password to prevent escalation
+  if (
+    !loading &&
+    !authEnabled &&
+    (location.pathname === "/login" || location.pathname === "/change-password")
+  ) {
+    return <Navigate to="/" replace />;
+  }
 
   // Don't guard the login or change-password pages
   if (

--- a/apps/web/src/components/settings/settings-dialog.tsx
+++ b/apps/web/src/components/settings/settings-dialog.tsx
@@ -202,6 +202,7 @@ interface TeamEntry {
 /* ────────────────────── General ────────────────────── */
 
 function GeneralSection() {
+  const { authEnabled } = useAuth();
   const [user, setUser] = useState<SessionUser | null>(null);
   const [loading, setLoading] = useState(true);
   const [defaultToolView, setDefaultToolView] = useState("sidebar");
@@ -277,14 +278,16 @@ function GeneralSection() {
             <p className="text-xs text-muted-foreground capitalize">{role}</p>
           </div>
         </div>
-        <button
-          type="button"
-          onClick={handleLogout}
-          className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-border text-sm text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
-        >
-          <LogOut className="h-3.5 w-3.5" />
-          Log out
-        </button>
+        {authEnabled && (
+          <button
+            type="button"
+            onClick={handleLogout}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-border text-sm text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+          >
+            <LogOut className="h-3.5 w-3.5" />
+            Log out
+          </button>
+        )}
       </div>
 
       {/* Default view */}


### PR DESCRIPTION
## Summary

- Fixes a security flaw where users with `AUTH_ENABLED=false` could log out, reach the login page, and authenticate with default `admin/admin` credentials to gain full admin privileges
- Implements defense-in-depth across five layers: backend admin seeding, login endpoint, session endpoint, frontend logout button, and frontend route guarding

## Changes

| Layer | File | Fix |
|-------|------|-----|
| Backend | `apps/api/src/index.ts` | Skip `ensureDefaultAdmin()` when auth is disabled |
| Backend | `apps/api/src/plugins/auth.ts` | Return 403 from `POST /api/auth/login` when auth is disabled |
| Backend | `apps/api/src/plugins/auth.ts` | Return synthetic anonymous user from `GET /api/auth/session` when auth is disabled |
| Frontend | `apps/web/src/components/settings/settings-dialog.tsx` | Hide logout button when auth is disabled |
| Frontend | `apps/web/src/App.tsx` | Redirect `/login` and `/change-password` to `/` via AuthGuard when auth is disabled |

Also fixed a pre-existing Biome lint suppression (`eslint-disable` → `biome-ignore`) in `App.tsx`.

## Test plan

- [x] Docker container with `AUTH_ENABLED=false`: no admin user seeded, login returns 403, session returns `anonymous/user`, logout button hidden, `/login` URL redirects to `/`
- [x] Docker container with `AUTH_ENABLED=true`: login works with valid credentials, rejects invalid, logout button visible, admin role displayed correctly
- [x] Image tool (info) works correctly with `AUTH_ENABLED=false`
- [x] `pnpm typecheck` — zero errors
- [x] `pnpm lint` — zero errors, zero warnings
- [x] `pnpm test:unit` — 586/586 passed
- [x] `pnpm test:integration` — 608/608 passed

Closes #90