### PR TITLE
fix: resolve features-store test timeouts in CI

### DIFF
--- a/tests/unit/web/features-store.test.ts
+++ b/tests/unit/web/features-store.test.ts
@@ -374,7 +374,9 @@ describe("useFeaturesStore", () => {
         }
         return Promise.resolve({});
       });
-      apiGetMock.mockResolvedValue({ bundles });
+      apiGetMock.mockResolvedValue({
+        bundles: bundles.map((b) => ({ ...b, status: "installed" })),
+      });
 
       const promise = useFeaturesStore.getState().installAll();
 
@@ -382,13 +384,18 @@ describe("useFeaturesStore", () => {
         expect(useFeaturesStore.getState().installAllActive).toBe(true);
       });
 
+      const completeAllOpen = () => {
+        for (const es of FakeEventSource.instances) {
+          if (!es.closed) {
+            es.onmessage?.({ data: JSON.stringify({ phase: "complete" }) });
+          }
+        }
+      };
+
       await vi.waitFor(() => {
         expect(FakeEventSource.instances.length).toBeGreaterThan(0);
       });
-
-      for (const es of FakeEventSource.instances) {
-        es.onmessage?.({ data: JSON.stringify({ phase: "complete" }) });
-      }
+      completeAllOpen();
 
       await vi
         .waitFor(
@@ -397,22 +404,17 @@ describe("useFeaturesStore", () => {
               throw new Error("waiting for second EventSource");
             }
           },
-          { timeout: 2000 },
+          { timeout: 5000 },
         )
         .catch(() => {});
-
-      for (const es of FakeEventSource.instances) {
-        if (!es.closed) {
-          es.onmessage?.({ data: JSON.stringify({ phase: "complete" }) });
-        }
-      }
+      completeAllOpen();
 
       await promise;
 
       const state = useFeaturesStore.getState();
       expect(state.installAllActive).toBe(false);
       expect(state.queued).toEqual([]);
-    });
+    }, 15000);
 
     it("clears stale errors for pending bundles", async () => {
       const bundles = [makeBundleState({ id: "err-bundle", status: "error" })];
@@ -423,7 +425,9 @@ describe("useFeaturesStore", () => {
       });
 
       apiPostMock.mockResolvedValue({ jobId: "job-err" });
-      apiGetMock.mockResolvedValue({ bundles });
+      apiGetMock.mockResolvedValue({
+        bundles: bundles.map((b) => ({ ...b, status: "installed" })),
+      });
 
       const promise = useFeaturesStore.getState().installAll();
 
@@ -440,7 +444,7 @@ describe("useFeaturesStore", () => {
       }
 
       await promise;
-    });
+    }, 15000);
   });
 
   describe("EventSource progress handling", () => {

--- a/tests/unit/web/zustand-stores.test.ts
+++ b/tests/unit/web/zustand-stores.test.ts
@@ -2677,13 +2677,15 @@ describe("useFeaturesStore", () => {
     );
 
     mockApiPost.mockResolvedValueOnce({ jobId: "job-clear" });
-    mockApiGet.mockResolvedValue({ bundles });
+    mockApiGet.mockResolvedValue({
+      bundles: bundles.map((b) => ({ ...b, status: "installed" as const })),
+    });
 
     await useFeaturesStore.getState().installAll();
 
     // Error should have been cleared at the start of installAll
     expect(useFeaturesStore.getState().errors["ai-rembg"]).toBeUndefined();
-  });
+  }, 15000);
 });
 
 // ==========================================================================


### PR DESCRIPTION
## Summary

Fixes 3 pre-existing unit test timeouts that have been failing in CI:

- `features-store.test.ts` - 2 tests timing out at 30s
- `zustand-stores.test.ts` - 1 test timing out at 30s

Root cause: `installAll()` has a real 2s `setTimeout` between queue items, and `refreshBundles()` mock returned bundles with unchanged `not_installed` status, causing the retry loop to re-queue and create an infinite cycle.

Fix: return `status: "installed"` from the `refreshBundles` mock (matching real behavior after a successful install) and increase test timeouts to 15s to accommodate the real 2s inter-install delays.

## Test plan

- [x] `pnpm vitest run tests/unit/web/features-store.test.ts` - 37/37 pass
- [x] `pnpm vitest run tests/unit/web/zustand-stores.test.ts` - 204/204 pass
- [x] `pnpm vitest run tests/unit/web/icon-map.test.ts` - 7/7 pass
- [x] All 248 tests across the 3 files pass