### PR TITLE
fix: increase timeout for AVIF conversion integration tests

### DIFF
--- a/tests/integration/format-matrix.test.ts
+++ b/tests/integration/format-matrix.test.ts
@@ -682,7 +682,8 @@ describe("Cross-format conversion matrix", () => {
       if (inputLower === outFmt) continue;
       if (inputLower === "jpeg" && outFmt === "jpg") continue;
 
-      it(`${fmt.name} -> ${outFmt}`, async () => {
+      const testTimeout = outFmt === "avif" ? 120_000 : 30_000;
+      it(`${fmt.name} -> ${outFmt}`, { timeout: testTimeout }, async () => {
         const fixturePath = join(FORMATS_DIR, fmt.file);
         if (!existsSync(fixturePath)) return;
 

--- a/tests/integration/new-formats.test.ts
+++ b/tests/integration/new-formats.test.ts
@@ -171,7 +171,8 @@ describe("New format support", () => {
       for (const outFmt of OUTPUTS) {
         const inLower = input.name.toLowerCase();
         if (inLower === outFmt || (inLower === "jpeg" && outFmt === "jpg")) continue;
-        it(`converts ${input.name} to ${outFmt}`, async () => {
+        const testTimeout = outFmt === "avif" ? 120_000 : 30_000;
+        it(`converts ${input.name} to ${outFmt}`, { timeout: testTimeout }, async () => {
           const fileBuffer = readFileSync(join(FORMATS_DIR, input.file));
           const { body, contentType } = createMultipartPayload([
             { name: "file", filename: input.file, contentType: input.mime, content: fileBuffer },


### PR DESCRIPTION
## Summary

AVIF encoding is slow in CI without hardware acceleration, causing `SVG -> avif` and `WebP -> avif` integration tests to timeout at the default 30s. Sets 120s timeout for all AVIF output conversion tests.

Pre-existing failure in Integration shard 2/4, unrelated to any recent feature work.

## Test plan

- [x] Verified these are the only 2 failing integration tests
- [x] Same tests were failing before any recent PRs (confirmed via earlier CI runs)