### PR TITLE
fix: increase timeout for remaining AVIF conversion tests

### DIFF
--- a/tests/integration/format-matrix-comprehensive.test.ts
+++ b/tests/integration/format-matrix-comprehensive.test.ts
@@ -927,7 +927,8 @@ describe("Extended conversion targets (core formats)", () => {
         if (fmt.name.toLowerCase() === target.format) continue;
         if (fmt.name === "AVIF" && target.format === "avif") continue;
 
-        it(`${fmt.name} -> ${target.format}`, async () => {
+        const testTimeout = target.format === "avif" ? 120_000 : 30_000;
+        it(`${fmt.name} -> ${target.format}`, { timeout: testTimeout }, async () => {
           const res = await callTool("convert", fmt, { format: target.format });
           if (!res) return;
           expect(res.statusCode).toBe(200);

--- a/tests/integration/format-matrix-expanded.test.ts
+++ b/tests/integration/format-matrix-expanded.test.ts
@@ -851,7 +851,8 @@ describe("SVG-to-raster", () => {
   const SVG_OUTPUT_FORMATS = ["png", "jpg", "webp", "avif"] as const;
 
   for (const outFmt of SVG_OUTPUT_FORMATS) {
-    it(`converts SVG to ${outFmt}`, async () => {
+    const testTimeout = outFmt === "avif" ? 120_000 : 30_000;
+    it(`converts SVG to ${outFmt}`, { timeout: testTimeout }, async () => {
       const fixturePath = join(FORMATS_DIR, "sample.svg");
       if (!existsSync(fixturePath)) return;
 


### PR DESCRIPTION
## Summary

Follow-up to #152. Two more AVIF conversion tests in shard 4/4 were timing out:
- `format-matrix-comprehensive.test.ts`: SVG -> avif
- `format-matrix-expanded.test.ts`: SVG to avif

Same fix: 120s timeout for AVIF output tests.

## Test plan

- [x] Matches the pattern from #152 which fixed shard 2/4