### PR TITLE
fix: correct Docker image name in compose files

### DIFF
--- a/docker/docker-compose-gpu.yml
+++ b/docker/docker-compose-gpu.yml
@@ -10,7 +10,7 @@ services:
     build:
       context: ..
       dockerfile: docker/Dockerfile
-    image: snapotter:latest
+    image: snapotter/snapotter:latest
     container_name: SnapOtter
     ports:
       # For internet-facing deployments, bind to localhost only:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     build:
       context: ..
       dockerfile: docker/Dockerfile
-    image: snapotter:latest
+    image: snapotter/snapotter:latest
     container_name: SnapOtter
     ports:
       # For internet-facing deployments, bind to localhost only:


### PR DESCRIPTION
## Summary
- Both `docker-compose.yml` and `docker-compose-gpu.yml` referenced `snapotter:latest` instead of `snapotter/snapotter:latest`, causing Docker to fail to pull the image from the registry.

Closes #182

## Test plan
- [ ] `docker compose config` parses without errors
- [ ] `docker compose pull` successfully pulls the image