### PR TITLE
fix: enable tiling in Real-ESRGAN to prevent CUDA OOM on 8GB GPUs

### DIFF
--- a/packages/ai/python/upscale.py
+++ b/packages/ai/python/upscale.py
@@ -129,10 +129,13 @@ def main():
                         num_grow_ch=32,
                         scale=4,
                     )
+                    tile_size = 512
                     upsampler = RealESRGANer(
                         scale=4,
                         model_path=REALESRGAN_MODEL_PATH,
                         model=ai_model,
+                        tile=tile_size,
+                        tile_pad=10,
                         half=use_gpu,
                         device=device,
                     )
@@ -140,7 +143,22 @@ def main():
 
                     img_array = np.array(img.convert("RGB"))
                     emit_progress(30, "Enhancing image with AI")
-                    output_array, _ = upsampler.enhance(img_array, outscale=scale)
+
+                    try:
+                        output_array, _ = upsampler.enhance(img_array, outscale=scale)
+                    except RuntimeError as oom_err:
+                        if "out of memory" not in str(oom_err).lower():
+                            raise
+                        torch.cuda.empty_cache()
+                        print(
+                            f"[upscale] OOM with tile={tile_size}, retrying with tile=256",
+                            file=sys.stderr,
+                            flush=True,
+                        )
+                        emit_progress(35, "Retrying with smaller tiles")
+                        upsampler.tile = 256
+                        output_array, _ = upsampler.enhance(img_array, outscale=scale)
+
                     emit_progress(80, "AI enhancement complete")
                     result = Image.fromarray(output_array)
                     method = "realesrgan"
@@ -161,12 +179,31 @@ def main():
                             channel_multiplier=2,
                             bg_upsampler=upsampler,
                         )
-                        _, _, face_output = face_enhancer.enhance(
-                            img_array,
-                            has_aligned=False,
-                            only_center_face=False,
-                            paste_back=True,
-                        )
+                        try:
+                            _, _, face_output = face_enhancer.enhance(
+                                img_array,
+                                has_aligned=False,
+                                only_center_face=False,
+                                paste_back=True,
+                            )
+                        except RuntimeError as oom_err:
+                            if "out of memory" not in str(oom_err).lower():
+                                raise
+                            torch.cuda.empty_cache()
+                            print(
+                                "[upscale] OOM during face enhance, retrying with tile=256",
+                                file=sys.stderr,
+                                flush=True,
+                            )
+                            emit_progress(84, "Retrying face enhancement")
+                            upsampler.tile = 256
+                            face_enhancer.bg_upsampler = upsampler
+                            _, _, face_output = face_enhancer.enhance(
+                                img_array,
+                                has_aligned=False,
+                                only_center_face=False,
+                                paste_back=True,
+                            )
                         result = Image.fromarray(face_output)
                         emit_progress(88, "Face enhancement complete")
 


### PR DESCRIPTION
## Summary
- Enable 512px tile-based processing in Real-ESRGAN instead of processing the entire image at once, reducing peak VRAM from "entire image" to "one tile + padding"
- Add OOM retry logic that catches CUDA out-of-memory errors, clears the cache, and retries with 256px tiles
- Covers both the main upscale path and the face enhancement (GFPGAN) path

## Context
Issue #191 reports CUDA OOM on an RTX 3070 (8GB) when upscaling a 1440x960 image at 4x. The `RealESRGANer` library natively supports tiling via its `tile` parameter, but we were leaving it at the default (`tile=0`, meaning no tiling). Most Real-ESRGAN deployments use `tile=400-512` by default.

Our own `noise_removal.py` already tiles images >2048px, and `background-removal.ts` has OOM retry logic. The upscale path had neither.

## Test plan
- [ ] Verify upscaling works on a GPU with 8GB VRAM (RTX 3070 or similar)
- [ ] Test with face enhance enabled (compounds VRAM usage with GFPGAN)
- [ ] Test with large images (4000x3000+) at 4x scale
- [ ] Verify no visible tile seam artifacts in output
- [ ] Verify lanczos fallback path is unaffected

Closes #191